### PR TITLE
Fix the deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,29 +19,29 @@ jobs:
       - run: npm test
       - persist_to_workspace:
           root: ~/repo
-          paths: .
-  release:
+          paths:
+            - .
+  deploy:
     <<: *defaults
     steps:
-    - attach_workspace:
-        at: ~/repo
-    # - run:
-    #     name: Authenticate with registry
-    #     command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
-    - run:
-        name: Publish package
-        command: npm publish
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Publish to NPM
+          command: |
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            npm publish
 
 workflows:
   version: 2
   npm-deploy:
     jobs:
       - test
-      - release:
-         requires:
-           - test
-         filters:
-          tags:
-            only: /^v.*/
-          branches:
-            only: master
+      - deploy:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
The `release` job (that I have renamed `deploy`) was triggered at each push on the `master` branch. I've fixed it such that the only trigger is the push of a new tag.