### PR TITLE
Test the CircleCi 'deploy' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Publish to NPM
           command: |
             npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-            npm publish
+            npm publish --dry-run
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.0.0-alpha.10",
+    "version": "1.0.0-alpha.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.0.0-alpha.10",
+    "version": "1.0.0-alpha.11",
     "description": "Reach5 Identity Web UI SDK",
     "author": "ReachFive",
     "repository": {


### PR DESCRIPTION
I've temporarily added the `-dry--run` option (https://docs.npmjs.com/cli/publish) to test the Circle ci `deploy` job.