### PR TITLE
Fix the 'deploy' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,10 @@ workflows:
   version: 2
   npm-deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test


### PR DESCRIPTION
The `deploy` job is not triggered when a new tag is pushed on the `master` branch.

According to this [discussion](https://discuss.circleci.com/t/build-workflow-not-triggered-when-tag-is-pushed/19577/4), the `test` job needed filters as well.