### PR TITLE
Use the env variables in the CircleCi "reachfive" context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ workflows:
             tags:
               only: /.*/
       - deploy:
+          context: reachfive
           requires:
             - test
           filters:


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1141396442496489/1180780219291915

The token used to authenticate to the npm repository was invalid (probably because it was generated by Egor who has no longer access to our project). So I've created a CircleCi context to group all the env variables required by both Web SDKs.

This PR changes the CircleCi configuration to use the NPM_TOKEN variable in the `reachfive` context.