### PR TITLE
Webauthn signup doesn't take into account  the `return_to_after_email_confirmation` param

### DIFF
--- a/src/widgets/auth/views/signupWithWebAuthnViewComponent.jsx
+++ b/src/widgets/auth/views/signupWithWebAuthnViewComponent.jsx
@@ -22,7 +22,8 @@ export default class SignupWithWebAuthnView extends React.Component {
         {
             profile: snakeCaseProperties(data),
             friendlyName: data.friendlyName,
-            redirectUrl: this.props && this.props.redirectUrl
+            redirectUrl: this.props && this.props.redirectUrl,
+            returnToAfterEmailConfirmation: this.props && this.props.returnToAfterEmailConfirmation
         },
         this.props.auth
     );


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1141396442496489/1199350022369287