### PR TITLE
Distinguish the data-test-id on the webauthn/password buttons

### DIFF
--- a/src/components/form/buttonComponent.jsx
+++ b/src/components/form/buttonComponent.jsx
@@ -8,14 +8,14 @@ import { withTheme } from '../widget/widgetContext';
 
 const buttonTheme = (props, attr) => props.theme.get(`${props.themePrefix || 'button'}.${attr}`);
 
-export const Button = styled(({ tagname = 'button', className, extendedClasses, title, disabled, type, onClick, children }) => {
+export const Button = styled(({ tagname = 'button', className, extendedClasses, title, disabled, type, dataTestId, onClick, children }) => {
     const Tagname = tagname;
 
     return (
         <Tagname className={classes([extendedClasses, className])}
             disabled={disabled}
             type={type}
-            data-testid={type}
+            data-testid={dataTestId || type}
             onClick={onClick}
             {...(title ? { title } : {})}>{children}</Tagname>
     );

--- a/src/components/form/webAuthAndPasswordButtonsComponent.jsx
+++ b/src/components/form/webAuthAndPasswordButtonsComponent.jsx
@@ -19,9 +19,10 @@ const iconStyle = `
 const FingerPrintIcon = styled(FingerPrint)`${iconStyle}`;
 const KeyboardIcon = styled(Keyboard)`${iconStyle}`;
 
-const PrimaryButtonWithIcon = styled(withTheme(({ type = "submit", onClick, disabled = false, title, text, children, theme, className }) => (
+const PrimaryButtonWithIcon = styled(withTheme(({ type = "submit", dataTestId, onClick, disabled = false, title, text, children, theme, className }) => (
     <Button
         type={type}
+        dataTestId={dataTestId}
         title={title}
         className={classes(['r5-button-with-icon'], className)}
         onClick={onClick}
@@ -52,6 +53,7 @@ const ButtonsSeparator = withTheme(styled.div`
 export const WebAuthnLoginViewButtons = styled(({ disabled, onPasswordClick, i18n, className }) => <div className={classes(['r5-webauthn-login-buttons'], className)}>
     <PrimaryButtonWithIcon
         type="submit"
+        dataTestId="webauthn-button"
         title={i18n('login.withBiometrics')}
         disabled={disabled}>
         <FingerPrintIcon />
@@ -60,6 +62,7 @@ export const WebAuthnLoginViewButtons = styled(({ disabled, onPasswordClick, i18
     <ButtonsSeparator>{i18n('or')}</ButtonsSeparator>
 
     <PrimaryButtonWithIcon
+        dataTestId="password-button"
         title={i18n('login.withPassword')}
         disabled={disabled}
         onClick={onPasswordClick}>
@@ -76,6 +79,7 @@ export const WebAuthnLoginViewButtons = styled(({ disabled, onPasswordClick, i18
 
 export const WebAuthnSignupViewButtons = styled(({ onBiometricClick, onPasswordClick, i18n, className }) => <div className={classes(['r5-webauthn-signup-buttons'], className)}>
     <PrimaryButtonWithIcon
+        dataTestId="webauthn-button"
         onClick={onBiometricClick}
         title={i18n('signup.withBiometrics')}
         text={i18n('biometrics')}>
@@ -85,6 +89,7 @@ export const WebAuthnSignupViewButtons = styled(({ onBiometricClick, onPasswordC
     <Separator text={i18n('or')} />
 
     <PrimaryButtonWithIcon
+        dataTestId="password-button"
         onClick={onPasswordClick}
         title={i18n('signup.withPassword')}
         text={i18n('password')}>

--- a/tests/widgets/auth/__snapshots__/authWidget.test.js.snap
+++ b/tests/widgets/auth/__snapshots__/authWidget.test.js.snap
@@ -6710,7 +6710,7 @@ exports[`Snapshot with webauthn feature login view with webauthn or password 1`]
       >
         <button
           className="c12 r5-button-with-icon c13"
-          data-testid="submit"
+          data-testid="webauthn-button"
           disabled={false}
           title="login.withBiometrics"
           type="submit"
@@ -6726,7 +6726,7 @@ exports[`Snapshot with webauthn feature login view with webauthn or password 1`]
         </div>
         <button
           className="c12 r5-button-with-icon c13"
-          data-testid="submit"
+          data-testid="password-button"
           disabled={false}
           onClick={[Function]}
           title="login.withPassword"
@@ -7651,7 +7651,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password  1
     >
       <button
         className="c7 r5-button-with-icon c8"
-        data-testid="submit"
+        data-testid="webauthn-button"
         disabled={false}
         onClick={[Function]}
         title="signup.withBiometrics"
@@ -7675,7 +7675,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password  1
       </div>
       <button
         className="c7 r5-button-with-icon c8"
-        data-testid="submit"
+        data-testid="password-button"
         disabled={false}
         onClick={[Function]}
         title="signup.withPassword"


### PR DESCRIPTION
The "password" and "webauthn" buttons cannot have the same `data-test-id` for the tests.