### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.12.0] - 2020-06-02
+
+### Changed
+
+Upgrade identity-web-core-sdk version to 1.20.1
+
 ## [1.11.7] - 2020-03-09
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.11.7",
+    "version": "1.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reachfive/identity-ui",
-            "version": "1.11.5",
+            "version": "1.12.0",
             "license": "MIT",
             "dependencies": {
                 "@hypnosphi/recompose": "0.30.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.11.7",
+    "version": "1.12.0",
     "description": "ReachFive Identity Web UI SDK",
     "author": "ReachFive",
     "repository": {


### PR DESCRIPTION
Bumps core-sdk to [1.20.1](https://github.com/ReachFive/identity-web-core-sdk/releases/tag/v1.20.1)