### PR TITLE
Support du champ autoComplete comme champ principal dans fieldCreator

### DIFF
--- a/src/components/form/fieldCreator.d.ts
+++ b/src/components/form/fieldCreator.d.ts
@@ -55,6 +55,7 @@ export interface FieldProps<T, F, P extends FieldComponentProps<F, ExtraParams>,
     defaultValue?: F
     required: boolean
     readOnly: boolean
+    autoComplete?: AutoFill
     validator?: Validator
     mapping?: PathMapping
     format?: Formatter<T, F>

--- a/src/components/form/fieldCreator.jsx
+++ b/src/components/form/fieldCreator.jsx
@@ -16,6 +16,7 @@ export const createField = ({
     defaultValue,
     required = true,
     readOnly = false,
+    autoComplete,
     validator = emptyRule,
     mapping = new PathMapping(camelCasePath(path)),
     format = {
@@ -36,6 +37,7 @@ export const createField = ({
             label: i18n(label),
             required,
             readOnly,
+            autoComplete,
             i18n,
             showLabel,
             ...extParams

--- a/src/components/form/fields/identifierField.jsx
+++ b/src/components/form/fields/identifierField.jsx
@@ -111,6 +111,7 @@ class IdentifierField extends React.Component {
                 value={value.raw || ''}
                 placeholder={placeholder}
                 title={label}
+                autoComplete={this.props.autoComplete}
                 required={required}
                 readOnly={readOnly}
                 hasError={!!validation.error}

--- a/src/components/form/fields/simpleField.jsx
+++ b/src/components/form/fields/simpleField.jsx
@@ -40,13 +40,12 @@ const SimpleField = props => {
     );
 };
 
-export const simpleField = ({ type, placeholder, autoComplete, ...config }) => createField({
+export const simpleField = ({ type, placeholder, ...config }) => createField({
     ...config,
     component: SimpleField,
     extendedParams: {
         type,
         placeholder,
-        autoComplete
     }
 });
 

--- a/src/components/form/fields/simplePasswordField.jsx
+++ b/src/components/form/fields/simplePasswordField.jsx
@@ -71,12 +71,11 @@ class SimplePasswordField extends React.Component {
     }
 }
 
-export const simplePasswordField = ({ placeholder, autoComplete, canShowPassword = false, ...config }) => createField({
+export const simplePasswordField = ({ placeholder, canShowPassword = false, ...config }) => createField({
     ...config,
     component: SimplePasswordField,
     extendedParams: {
         placeholder,
-        autoComplete,
         canShowPassword
     }
 });


### PR DESCRIPTION
Avant c'était uniquement supporté dans les extraParams et donc ne pouvait pas être typé.