### PR TITLE
[CA-3450] La composition d'un custom_field de type date est toujours vérifié, même s'il est facultatif

### DIFF
--- a/src/components/form/fields/dateField.jsx
+++ b/src/components/form/fields/dateField.jsx
@@ -159,7 +159,7 @@ export default function dateField(props, config) {
                 const dt = value ? DateTime.fromISO(value) : DateTime.invalid('empty value')
                 return dt.isValid ? { raw: dt } : undefined
             },
-            unbind: (value) => value.raw.toISODate()
+            unbind: (value) => value && value.raw.toISODate()
         },
         validator: props.validator ? datetimeValidator(config.language).and(props.validator) : datetimeValidator(config.language),
         component: DateField,


### PR DESCRIPTION
[CA-3450](https://reach5.atlassian.net/browse/CA-3450)

[CA-3450]: https://reach5.atlassian.net/browse/CA-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ