### PR TITLE
Fix: styled-component's react hook warning due to react version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,12 @@
             "dependencies": {
                 "@reachfive/identity-core": "^1.32.0",
                 "@reachfive/zxcvbn": "1.0.0-alpha.2",
-                "@rollup/rollup-linux-x64-gnu": "^4.12.0",
                 "buffer": "^6.0.3",
                 "char-info": "0.3.2",
                 "classnames": "^2.3.2",
                 "libphonenumber-js": "^1.10.44",
                 "lodash-es": "4.17.21",
                 "luxon": "^3.4.3",
-                "react": "^16.14.0",
-                "react-dom": "^16.14.0",
                 "react-transition-group": "4.4.2",
                 "remarkable": "2.0.1",
                 "validator": "^13.11.0"
@@ -73,6 +70,8 @@
                 "@rollup/rollup-linux-x64-gnu": "^4.12.0"
             },
             "peerDependencies": {
+                "react": "^16.14.0",
+                "react-dom": "^16.14.0",
                 "styled-components": "5.1.1"
             }
         },
@@ -10135,6 +10134,7 @@
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
             "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -10148,6 +10148,7 @@
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
             "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
                 "libphonenumber-js": "^1.10.44",
                 "lodash-es": "4.17.21",
                 "luxon": "^3.4.3",
+                "react": "^16.14.0",
+                "react-dom": "^16.14.0",
                 "react-transition-group": "4.4.2",
                 "remarkable": "2.0.1",
                 "validator": "^13.11.0"
@@ -35,7 +37,7 @@
                 "@rollup/plugin-url": "^8.0.2",
                 "@svgr/rollup": "^8.1.0",
                 "@testing-library/jest-dom": "^6.2.0",
-                "@testing-library/react": "^14.0.0",
+                "@testing-library/react": "^12.1.5",
                 "@types/babel__generator": "^7.6.6",
                 "@types/lodash-es": "^4.17.9",
                 "@types/react": "^18.2.23",
@@ -59,7 +61,7 @@
                 "jest-environment-jsdom": "^29.7.0",
                 "jest-styled-components": "^7.2.0",
                 "polished": "^4.2.2",
-                "react-test-renderer": "^18.2.0",
+                "react-test-renderer": "^16.14.0",
                 "rollup": "^4.1.4",
                 "rollup-plugin-dts": "^6.1.0",
                 "rollup-plugin-esbuild": "^6.1.0",
@@ -71,8 +73,6 @@
                 "@rollup/rollup-linux-x64-gnu": "^4.12.0"
             },
             "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
                 "styled-components": "5.1.1"
             }
         },
@@ -3350,9 +3350,10 @@
             }
         },
         "node_modules/@testing-library/dom": {
-            "version": "9.3.3",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+            "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -3364,13 +3365,14 @@
                 "pretty-format": "^27.0.2"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=12"
             }
         },
         "node_modules/@testing-library/dom/node_modules/ansi-styles": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -3383,16 +3385,18 @@
         },
         "node_modules/@testing-library/dom/node_modules/aria-query": {
             "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "deep-equal": "^2.0.5"
             }
         },
         "node_modules/@testing-library/dom/node_modules/chalk": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3406,8 +3410,9 @@
         },
         "node_modules/@testing-library/dom/node_modules/color-convert": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -3417,21 +3422,24 @@
         },
         "node_modules/@testing-library/dom/node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/@testing-library/dom/node_modules/has-flag": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@testing-library/dom/node_modules/supports-color": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3548,20 +3556,41 @@
             }
         },
         "node_modules/@testing-library/react": {
-            "version": "14.0.0",
+            "version": "12.1.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+            "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^9.0.0",
-                "@types/react-dom": "^18.0.0"
+                "@testing-library/dom": "^8.0.0",
+                "@types/react-dom": "<18.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=12"
             },
             "peerDependencies": {
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0"
+                "react": "<18.0.0",
+                "react-dom": "<18.0.0"
+            }
+        },
+        "node_modules/@testing-library/react/node_modules/@types/react": {
+            "version": "17.0.76",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.76.tgz",
+            "integrity": "sha512-w9Aq+qeszGYoQM0hgFcdsAODGJdogadBDiitPm+zjBFJ0mLymvn2qSXsDaLJUndFRqqXk1FQfa9avHUBk1JhJQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@testing-library/react/node_modules/@types/react-dom": {
+            "version": "17.0.25",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+            "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "^17"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -3601,9 +3630,10 @@
             "license": "MIT"
         },
         "node_modules/@types/aria-query": {
-            "version": "5.0.3",
-            "dev": true,
-            "license": "MIT"
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.3",
@@ -4584,7 +4614,8 @@
         },
         "node_modules/babel-plugin-styled-components": {
             "version": "2.1.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+            "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
             "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -4770,13 +4801,19 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.5",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5312,14 +5349,15 @@
             }
         },
         "node_modules/deep-equal": {
-            "version": "2.2.2",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.5",
                 "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.1",
+                "get-intrinsic": "^1.2.2",
                 "is-arguments": "^1.1.1",
                 "is-array-buffer": "^3.0.2",
                 "is-date-object": "^1.0.5",
@@ -5329,11 +5367,14 @@
                 "object-is": "^1.1.5",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.0",
+                "regexp.prototype.flags": "^1.5.1",
                 "side-channel": "^1.0.4",
                 "which-boxed-primitive": "^1.0.2",
                 "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.9"
+                "which-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5353,16 +5394,20 @@
             }
         },
         "node_modules/define-data-property": {
-            "version": "1.1.1",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/define-properties": {
@@ -5445,8 +5490,9 @@
         },
         "node_modules/dom-accessibility-api": {
             "version": "0.5.16",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -5626,10 +5672,32 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-get-iterator": {
             "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.3",
@@ -6489,14 +6557,19 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.2",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
                 "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6920,8 +6993,9 @@
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -9402,8 +9476,9 @@
         },
         "node_modules/lz-string": {
             "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -9621,12 +9696,13 @@
             }
         },
         "node_modules/object-is": {
-            "version": "1.1.5",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9939,8 +10015,9 @@
         },
         "node_modules/pretty-format": {
             "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -9952,8 +10029,9 @@
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -9963,8 +10041,9 @@
         },
         "node_modules/pretty-format/node_modules/react-is": {
             "version": "17.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true
         },
         "node_modules/prompts": {
             "version": "2.4.2",
@@ -10053,56 +10132,56 @@
             }
         },
         "node_modules/react": {
-            "version": "18.2.0",
-            "license": "MIT",
-            "peer": true,
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
             "dependencies": {
-                "loose-envify": "^1.1.0"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "18.2.0",
-            "license": "MIT",
-            "peer": true,
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+            "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.0"
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.19.1"
             },
             "peerDependencies": {
-                "react": "^18.2.0"
+                "react": "^16.14.0"
             }
         },
         "node_modules/react-is": {
             "version": "18.2.0",
             "license": "MIT"
         },
-        "node_modules/react-shallow-renderer": {
-            "version": "16.15.0",
+        "node_modules/react-test-renderer": {
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+            "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4.1.1",
-                "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+                "prop-types": "^15.6.2",
+                "react-is": "^16.8.6",
+                "scheduler": "^0.19.1"
             },
             "peerDependencies": {
-                "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+                "react": "^16.14.0"
             }
         },
-        "node_modules/react-test-renderer": {
-            "version": "18.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "react-is": "^18.2.0",
-                "react-shallow-renderer": "^16.15.0",
-                "scheduler": "^0.23.0"
-            },
-            "peerDependencies": {
-                "react": "^18.2.0"
-            }
+        "node_modules/react-test-renderer/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
         },
         "node_modules/react-transition-group": {
             "version": "4.4.2",
@@ -10497,10 +10576,12 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.0",
-            "license": "MIT",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+            "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
             "dependencies": {
-                "loose-envify": "^1.1.0"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "node_modules/semver": {
@@ -10520,14 +10601,17 @@
             }
         },
         "node_modules/set-function-length": {
-            "version": "1.1.1",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+            "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
+                "define-data-property": "^1.1.2",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.3",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "has-property-descriptors": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10665,8 +10749,9 @@
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "internal-slot": "^1.0.4"
             },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "validator": "^13.11.0"
     },
     "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
         "styled-components": "5.1.1"
     },
     "devDependencies": {
@@ -61,7 +61,7 @@
         "@rollup/plugin-url": "^8.0.2",
         "@svgr/rollup": "^8.1.0",
         "@testing-library/jest-dom": "^6.2.0",
-        "@testing-library/react": "^14.0.0",
+        "@testing-library/react": "^12.1.5",
         "@types/babel__generator": "^7.6.6",
         "@types/lodash-es": "^4.17.9",
         "@types/react": "^18.2.23",
@@ -85,7 +85,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-styled-components": "^7.2.0",
         "polished": "^4.2.2",
-        "react-test-renderer": "^18.2.0",
+        "react-test-renderer": "^16.14.0",
         "rollup": "^4.1.4",
         "rollup-plugin-dts": "^6.1.0",
         "rollup-plugin-esbuild": "^6.1.0",


### PR DESCRIPTION
Resolves this kind of warning message in tests execution : 
```
console.error
    Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
    1. You might have mismatching versions of React and the renderer (such as React DOM)
    2. You might be breaking the Rules of Hooks
    3. You might have more than one copy of React in the same app
    See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
``` 