### PR TITLE
Fix: not wrapped in act warning issue in tests

### DIFF
--- a/tests/widgets/socialAccounts/socialAccountsWidget.test.js
+++ b/tests/widgets/socialAccounts/socialAccountsWidget.test.js
@@ -28,13 +28,15 @@ describe('Snapshot', () => {
             { config, apiClient }
         )
 
-        const { container, rerender } = await render(widget);
+        await waitFor(async () => {
+            const { container, rerender } = await render(widget);
 
-        await waitFor(() => expect(apiClient.getUser).toHaveBeenCalled())
-
-        await rerender(widget)
-        
-        expect(container).toMatchSnapshot();
+            await waitFor(() => expect(apiClient.getUser).toHaveBeenCalled())
+    
+            await rerender(widget)
+            
+            expect(container).toMatchSnapshot();
+        })
     };
 
     test('basic', generateSnapshot({
@@ -61,11 +63,13 @@ describe('DOM testing', () => {
             { config, apiClient }
         )
 
-        const { rerender } = await render(widget);
+        await waitFor(async () => {
+            const { rerender } = await render(widget);
 
-        await waitFor(() => expect(apiClient.getUser).toHaveBeenCalled())
+            await waitFor(() => expect(apiClient.getUser).toHaveBeenCalled())
 
-        return await rerender(widget)
+            await rerender(widget)
+        })
     };
 
     describe('with default config', () => {


### PR DESCRIPTION
Fix this kind of warning :
```
console.error
      Warning: An update to withIdentities(Component) inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
```