### PR TITLE
[CA-3447] [showSocialAccounts] Link : afficher le bon variant et non celui par défaut

### DIFF
--- a/src/widgets/socialAccounts/socialAccountsWidget.tsx
+++ b/src/widgets/socialAccounts/socialAccountsWidget.tsx
@@ -30,7 +30,7 @@ interface WithIdentitiesProps {
 
 function findAvailableProviders(providers: string[], identities: Identity[]): string[] {
     return providers.filter(provider => {
-        const providerName = provider.split('').shift();
+        const providerName = provider.split(':').shift();
         return identities.findIndex(i => i.provider == providerName) == -1;
     });
 } 


### PR DESCRIPTION
The existing code will strip the variant from the available providers, we don't want that.