### PR TITLE
[CA-3614] Fix: Lookbehind in regular expression not implemented on Safari on iOS <16.4

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -79,7 +79,7 @@ export function isValidEmail(email: string) {
 
 export function camelCase(string: string) {
     return string
-    .replace(/((?<![A-Z])[A-Z])/g, ' $1')
+    .replace(/([^A-Z])([A-Z])/g, '$1 $2') // "aB" become "a B"
     .toLowerCase()
     .replace(/[^a-z0-9]/ig, ' ')
     .trim()


### PR DESCRIPTION
[JIRA](https://reach5.atlassian.net/browse/CA-3614)

https://caniuse.com/js-regexp-lookbehind