### PR TITLE
fix error message handling

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -185,11 +185,15 @@ export class UiClient {
         }
     }
 
-    adaptError(error: unknown) {
-        return error instanceof UserError ? error.isUserError : error instanceof Error ? error.message : 'Unexpected error'
+    adaptError(error: unknown): string {
+        return error instanceof UserError
+            ? error.message
+            : error instanceof Error 
+                ? error.message 
+                : 'Unexpected error'
     }
 
-    handleError(error: unknown) {
+    handleError(error: unknown): void {
         if (error instanceof UserError) {
             const message = this.adaptError(error)
             logError(`ReachFive widget display fails: ${message}`);


### PR DESCRIPTION
Les messages d'erreurs utilisateurs qui doivent être affiché à la place du composant si il y a un problème sont mal capté et ne s'affichent donc pas.