### PR TITLE
Fix SocialAccount auth config forwarding

### DIFF
--- a/src/widgets/socialAccounts/socialAccountsWidget.tsx
+++ b/src/widgets/socialAccounts/socialAccountsWidget.tsx
@@ -46,30 +46,28 @@ const withIdentities = <T extends WithIdentitiesProps = WithIdentitiesProps>(
         const { goTo } = useRouting()
         const [identities, setIdentities] = useState<Identity[]>([])
 
-        const { accessToken, auth, ...componentProps } = props
-
         const refresh = useCallback(() => {
             coreClient
                 .getUser({
-                    accessToken: accessToken,
+                    accessToken: props.accessToken,
                     fields: 'social_identities{id,provider,username}'
                 })
                 .then(({ socialIdentities }: Profile) => {
                     setIdentities(socialIdentities as Identity[])
                 });
-        }, [accessToken, coreClient])
+        }, [props.accessToken, coreClient])
 
         const unlink = useCallback((identityId: string) => {
             const prevIdentities = identities
             // Optimistic update
             setIdentities(identities.filter(i => i.id !== identityId))
             // api call + catch failure
-            return coreClient.unlink({ accessToken, identityId }).catch(error => {
+            return coreClient.unlink({ accessToken: props.accessToken, identityId }).catch(error => {
                 // restore previous identities
                 setIdentities(prevIdentities)
                 return Promise.reject(error)
             })
-        }, [accessToken, coreClient, identities])
+        }, [props.accessToken, coreClient, identities])
 
         const handleAuthenticated = useCallback(() => {
             refresh()
@@ -77,14 +75,20 @@ const withIdentities = <T extends WithIdentitiesProps = WithIdentitiesProps>(
         }, [goTo, refresh])
 
         useEffect(() => {
-            if (auth?.popupMode) {
+            if (props.auth?.popupMode) {
                 coreClient.on('authenticated', handleAuthenticated);
             }
             refresh();
             return () => coreClient.off('authenticated', handleAuthenticated)
-        }, [coreClient, auth, handleAuthenticated, refresh])
+        }, [coreClient, props.auth, handleAuthenticated, refresh])
         
-        return <WrappedComponent {...(componentProps as T)} identities={identities} unlink={unlink} />;
+        return (
+            <WrappedComponent
+                {...(props as T)}
+                identities={identities}
+                unlink={unlink}
+            />
+        );
     };
   
     ComponentWithIdentities.displayName = `withIdentities(${displayName})`;


### PR DESCRIPTION
La décomposition des propriétés dans le HoC `withIdentities` extrayait les propriétés `accessToken` et `auth` pour son usage personnel et ne les forwardait pas ensuite au composant enfant qui peut (et c'est le cas) en avoir aussi besoin.