### PR TITLE
[CA-3587] MFA stepUp main view initialization and rendering conditions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "@svgr/rollup": "^8.1.0",
                 "@testing-library/jest-dom": "^6.2.0",
                 "@testing-library/react": "^12.1.5",
+                "@testing-library/user-event": "^14.5.2",
                 "@types/babel__generator": "^7.6.6",
                 "@types/react": "^16.9.24",
                 "@types/react-dom": "^16.9.24",
@@ -3875,6 +3876,19 @@
             "peerDependencies": {
                 "react": "<18.0.0",
                 "react-dom": "<18.0.0"
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.5.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+            "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
             }
         },
         "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "@svgr/rollup": "^8.1.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/user-event": "^14.5.2",
         "@types/babel__generator": "^7.6.6",
         "@types/react": "^16.9.24",
         "@types/react-dom": "^16.9.24",

--- a/tests/widgets/mfa/mfaStepUpWidget.test.js
+++ b/tests/widgets/mfa/mfaStepUpWidget.test.js
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, afterAll, beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from "@testing-library/user-event";
+import '@testing-library/jest-dom'
+import 'jest-styled-components';
+
+import mfaStepUpWidget from '../../../src/widgets/stepUp/mfaStepUpWidget';
+
+const defaultConfig = { domain: 'local.reach5.net', language: 'fr' };
+
+const auth = {
+    redirectUri: 'http://localhost/'
+};
+
+const authType = 'sms';
+const myStepUpToken = 'myStepUpToken';
+const myChallengeId = 'myChallengeId';
+const myVerificationCode = '1234';
+
+const apiClient = {
+    getMfaStepUpToken: jest.fn().mockResolvedValue({
+        amr: [authType],
+        token: myStepUpToken,
+    }),
+    startPasswordless: jest.fn().mockResolvedValue({
+        challengeId: myChallengeId,
+    }),
+    verifyMfaPasswordless: jest.fn().mockResolvedValue({})
+};
+
+describe('DOM testing', () => {
+    const { location } = window;
+
+    afterEach(() => {
+        apiClient.getMfaStepUpToken?.mockClear();
+        apiClient.startPasswordless?.mockClear();
+        window.location.replace?.mockClear();
+    })
+
+    beforeAll(() => {
+        delete window.location;
+        window.location = { replace: jest.fn() };
+    })
+
+    afterAll(() => {
+        window.location = location;
+    })
+
+    const generateComponent = async (options = {}, config = defaultConfig) => {
+        const result = await mfaStepUpWidget(options, { config, apiClient });
+        return render(result);
+    };
+
+    const assertStepUpWorkflow = async (user) => {
+        return await waitFor(async () => {
+            expect(apiClient.getMfaStepUpToken).toHaveBeenCalledTimes(1);
+
+            expect(apiClient.startPasswordless).toHaveBeenNthCalledWith(1,
+                expect.objectContaining({
+                    authType: expect.stringMatching(authType),
+                    stepUp: expect.stringMatching(myStepUpToken),
+                })
+            );
+
+            expect(screen.queryByText('passwordless.sms.verification.intro')).toBeInTheDocument();
+            expect(screen.queryByLabelText('verificationCode')).toBeInTheDocument();
+            const input = screen.queryByPlaceholderText('verificationCode')
+            expect(input).toBeInTheDocument();
+            const submitBtn = screen.queryByTestId('submit')
+            expect(submitBtn).toBeInTheDocument();
+
+            await user.type(input, myVerificationCode);
+            await user.click(submitBtn);
+
+            expect(apiClient.verifyMfaPasswordless).toHaveBeenNthCalledWith(1,
+                expect.objectContaining({
+                    challengeId: expect.stringMatching(myChallengeId),
+                    verificationCode: expect.stringMatching(myVerificationCode),
+                })
+            )
+
+            expect(window.location.replace).toHaveBeenCalledWith(
+                expect.stringContaining(auth.redirectUri)
+            )
+        })
+    }
+
+    describe('mfaStepUp', () => {
+        test('showStepUpStart: true', async () => {
+            expect.assertions(9);
+
+            const user = userEvent.setup()
+
+            await waitFor(async () => {
+                await generateComponent({
+                    auth,
+                    showStepUpStart: true
+                }, defaultConfig, []);
+                
+                // StepUp start button
+                const stepUpStartBtn = screen.queryByText('mfa.stepUp.start')
+                expect(stepUpStartBtn).toBeInTheDocument();
+
+                await user.click(stepUpStartBtn);
+
+                await assertStepUpWorkflow(user)
+            })
+        })
+
+        test('showStepUpStart: false', async () => {
+            expect.assertions(11);
+
+            const user = userEvent.setup()
+
+            await waitFor(async () => {
+                await generateComponent({
+                    auth,
+                    showStepUpStart: false
+                }, defaultConfig, []);
+
+                // StepUp start button
+                expect(screen.queryByText('mfa.stepUp.start')).not.toBeInTheDocument();
+
+                await assertStepUpWorkflow(user)
+            })
+        })
+    })
+
+})

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
- * @reachfive/identity-ui - v1.25.3
- * Compiled Thu, 21 Mar 2024 17:10:31 UTC
+ * @reachfive/identity-ui - v1.25.5
+ * Compiled Fri, 05 Apr 2024 13:18:41 UTC
  *
  * Copyright (c) ReachFive.
  *
@@ -552,6 +552,7 @@ interface MainViewProps$5 {
 type FaSelectionViewState = MFA.StepUpResponse;
 type FaSelectionViewProps = Prettify<Partial<MFA.StepUpResponse> & {
     showIntro?: boolean;
+    auth?: AuthOptions;
 }>;
 type StepUpResponse = RequiredProperty<PasswordlessResponse, 'challengeId'>;
 type StepUpHandlerResponse = StepUpResponse & StartPasswordlessFormData;


### PR DESCRIPTION
[CA-3587](https://reach5.atlassian.net/browse/CA-3587)

La gestion de l'option `showStepUpStart` qui permet de choisir entre afficher un bouton pour exécuter la requête requestStepUp manuellement ou de l'exécuter à l'affichage n'était pas bien géré et résultat d'une page blanch à l'affichage.

[CA-3587]: https://reach5.atlassian.net/browse/CA-3587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ