### PR TITLE
[CA-4020] Transform empty string to null value for sending.

### DIFF
--- a/src/components/form/fields/phoneNumberField.tsx
+++ b/src/components/form/fields/phoneNumberField.tsx
@@ -168,10 +168,7 @@ const phoneNumberField = (
                 }
             },
             unbind: formValue => {
-                return (
-                    typeof formValue === 'object' && 'raw' in formValue ?
-                        (formValue.raw == '' ? null : formValue.raw) :
-                        formValue) ?? null
+                return (typeof formValue === 'object' && 'raw' in formValue ? formValue.raw : formValue) || null
             }
         },
         validator: new Validator<Value>({

--- a/src/components/form/fields/phoneNumberField.tsx
+++ b/src/components/form/fields/phoneNumberField.tsx
@@ -161,10 +161,6 @@ const phoneNumberField = (
         format: {
             bind: (value) => {
                 const phoneNumber = value ? parsePhoneNumber(value) : undefined
-                console.log("VALUE: " +value)
-                console.log("PHONE NUMBER: " +phoneNumber)
-                console.log("PHNE NUMBER NUMBER" + phoneNumber?.number)
-                console.log("RAW" + (phoneNumber?.number ?? '' as Value))
                 return {
                     country: phoneNumber?.country,
                     raw: phoneNumber?.number ?? '' as Value,
@@ -172,7 +168,6 @@ const phoneNumberField = (
                 }
             },
             unbind: formValue => {
-                console.log("FORM RAW" + JSON.stringify(formValue, null,2))
                 return (
                     typeof formValue === 'object' && 'raw' in formValue ?
                         (formValue.raw == '' ? null : formValue.raw) :

--- a/src/components/form/fields/phoneNumberField.tsx
+++ b/src/components/form/fields/phoneNumberField.tsx
@@ -18,7 +18,7 @@ function isValidCountryCode(code?: string): code is Country {
 
 const PhoneInputStyles = styled.div`
     ${styles}
-    
+
     --PhoneInput-color--focus: ${props => props.theme.primaryColor};
     --PhoneInputCountrySelect-marginRight: ${props => props.theme.spacing}px;
     --PhoneInputCountrySelectArrow-marginLeft: var(--PhoneInputCountrySelect-marginRight);
@@ -26,7 +26,7 @@ const PhoneInputStyles = styled.div`
 	--PhoneInputCountrySelectArrow-transform: rotate(45deg);
     --PhoneInputCountrySelectArrow-width: 0.3em;
     --PhoneInputCountryFlag-height: ${props => props.theme.input.height - ((props.theme.input.paddingY + props.theme.input.borderWidth) * 2)}px;
-    
+
 `
 
 function importLocale(locale: string) {
@@ -52,7 +52,7 @@ export interface PhoneNumberFieldProps extends FieldComponentProps<Value>, Phone
      */
     defaultCountry?: Country
     /**
-     * If country is specified then the phone number can only be input in "national" (not "international") format, 
+     * If country is specified then the phone number can only be input in "national" (not "international") format,
      * and will be parsed as a phonenumber belonging to the country.
      */
     country?: Country
@@ -88,7 +88,7 @@ const PhoneNumberField = (props: PhoneNumberFieldProps) => {
                 setLabels(result)
             }
         }
-        /** 
+        /**
          * @node the ignore variable which is initialized to false, and is set to true during cleanup.
          * This ensures your code doesn’t suffer from “race conditions”: network responses may arrive in a different order than you sent them.
          */
@@ -161,6 +161,10 @@ const phoneNumberField = (
         format: {
             bind: (value) => {
                 const phoneNumber = value ? parsePhoneNumber(value) : undefined
+                console.log("VALUE: " +value)
+                console.log("PHONE NUMBER: " +phoneNumber)
+                console.log("PHNE NUMBER NUMBER" + phoneNumber?.number)
+                console.log("RAW" + (phoneNumber?.number ?? '' as Value))
                 return {
                     country: phoneNumber?.country,
                     raw: phoneNumber?.number ?? '' as Value,
@@ -168,7 +172,11 @@ const phoneNumberField = (
                 }
             },
             unbind: formValue => {
-                return (typeof formValue === 'object' && 'raw' in formValue ? formValue.raw : formValue) ?? null
+                console.log("FORM RAW" + JSON.stringify(formValue, null,2))
+                return (
+                    typeof formValue === 'object' && 'raw' in formValue ?
+                        (formValue.raw == '' ? null : formValue.raw) :
+                        formValue) ?? null
             }
         },
         validator: new Validator<Value>({

--- a/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
+++ b/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
@@ -53,7 +53,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
                 phoneNumber
               </label>
               <div
-                class="sc-fzqNJr hkzLPg"
+                class="sc-fzqNJr eQTqfM"
               >
                 <input
                   autocomplete="tel"
@@ -115,7 +115,7 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
                 phoneNumber
               </label>
               <div
-                class="sc-fzqNJr hkzLPg"
+                class="sc-fzqNJr eQTqfM"
               >
                 <input
                   autocomplete="tel"


### PR DESCRIPTION
[CA-4020](https://reach5.atlassian.net/browse/CA-4020)

In this PR:
- phone number field now sends null instead of an empty string when the widget is empty at loading

[CA-4020]: https://reach5.atlassian.net/browse/CA-4020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ