### PR TITLE
[CA-4412] Le sélecteur de country dans de champ PhoneNumber n'apparait pas à la bonne taille sur Safari desktop et iOS

### DIFF
--- a/src/components/form/fields/phoneNumberField.tsx
+++ b/src/components/form/fields/phoneNumberField.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { default as PhoneInputWithCountrySelect, isSupportedCountry, parsePhoneNumber } from 'react-phone-number-input'
 import { default as PhoneInputWithoutCountrySelect } from 'react-phone-number-input/input';
 import type { Country, Labels, Value } from 'react-phone-number-input';
-import styled from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 
 import styles from 'react-phone-number-input/style.css'; // import raw css using `rollup-plugin-import-css'`
 
@@ -16,17 +16,18 @@ function isValidCountryCode(code?: string): code is Country {
     return typeof code === 'string' && isSupportedCountry(code)
 }
 
-const PhoneInputStyles = styled.div`
+const ReactPhoneNumberInputStyle = createGlobalStyle`
     ${styles}
 
-    --PhoneInput-color--focus: ${props => props.theme.primaryColor};
-    --PhoneInputCountrySelect-marginRight: ${props => props.theme.spacing}px;
-    --PhoneInputCountrySelectArrow-marginLeft: var(--PhoneInputCountrySelect-marginRight);
-    --PhoneInputCountrySelectArrow-borderWidth: 2px;
-	--PhoneInputCountrySelectArrow-transform: rotate(45deg);
-    --PhoneInputCountrySelectArrow-width: 0.3em;
-    --PhoneInputCountryFlag-height: ${props => props.theme.input.height - ((props.theme.input.paddingY + props.theme.input.borderWidth) * 2)}px;
-
+    :root {
+        --PhoneInput-color--focus: ${props => props.theme.primaryColor};
+        --PhoneInputCountrySelect-marginRight: ${props => props.theme.spacing}px;
+        --PhoneInputCountrySelectArrow-marginLeft: var(--PhoneInputCountrySelect-marginRight);
+        --PhoneInputCountrySelectArrow-borderWidth: 2px;
+        --PhoneInputCountrySelectArrow-transform: rotate(45deg);
+        --PhoneInputCountrySelectArrow-width: 0.3em;
+        --PhoneInputCountryFlag-height: ${props => props.theme.input.height - ((props.theme.input.paddingY + props.theme.input.borderWidth) * 2)}px;
+    }
 `
 
 function importLocale(locale: string) {
@@ -123,30 +124,29 @@ const PhoneNumberField = (props: PhoneNumberFieldProps) => {
             {...{ error }}
             showLabel={showLabel}
         >
-            <PhoneInputStyles>
-                <PhoneInput
-                    id={inputId}
-                    name={path}
-                    value={currentValue}
-                    placeholder={placeholder}
-                    required={required}
-                    data-testid="phone_number"
-                    onChange={handlePhoneChange}
-                    labels={labels}
-                    international={true}
-                    withCountryCallingCode={withCountryCallingCode}
-                    {...(withCountrySelect
-                        ? ({
-                            defaultCountry: country,
-                        })
-                        : ({
-                            country,
-                        })
-                    )}
-                    inputComponent={Input}
-                    hasError={!!error}
-                />
-            </PhoneInputStyles>
+            <ReactPhoneNumberInputStyle />
+            <PhoneInput
+                id={inputId}
+                name={path}
+                value={currentValue}
+                placeholder={placeholder}
+                required={required}
+                data-testid="phone_number"
+                onChange={handlePhoneChange}
+                labels={labels}
+                international={true}
+                withCountryCallingCode={withCountryCallingCode}
+                {...(withCountrySelect
+                    ? ({
+                        defaultCountry: country,
+                    })
+                    : ({
+                        country,
+                    })
+                )}
+                inputComponent={Input}
+                hasError={!!error}
+            />
         </FormGroup>
     );
 }

--- a/src/types/css-modules.d.ts
+++ b/src/types/css-modules.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CSS module files
 
 declare module '*.css' {
-    const content: Record<string, string>;
+    const content: string;
     export default content;
 }

--- a/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
+++ b/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
@@ -7,7 +7,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
   >
     <div>
       <div
-        class="sc-fzpjYC fZFmJB"
+        class="sc-fzoXzr jzxwMq"
       >
         <div>
           <div
@@ -52,21 +52,17 @@ exports[`Snapshot mfaCredentials default 1`] = `
               >
                 phoneNumber
               </label>
-              <div
-                class="sc-fzoXzr hEdSyY"
-              >
-                <input
-                  autocomplete="tel"
-                  class="sc-fznyAO eZfilo"
-                  data-testid="phone_number"
-                  id="phone_number"
-                  name="phone_number"
-                  placeholder="phoneNumber"
-                  required=""
-                  type="tel"
-                  value=""
-                />
-              </div>
+              <input
+                autocomplete="tel"
+                class="sc-fznyAO eZfilo"
+                data-testid="phone_number"
+                id="phone_number"
+                name="phone_number"
+                placeholder="phoneNumber"
+                required=""
+                type="tel"
+                value=""
+              />
             </div>
             <button
               class="sc-fzqNJr gWXXZS"
@@ -79,7 +75,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
         </div>
       </div>
       <div
-        class="sc-fzpjYC fZFmJB"
+        class="sc-fzoXzr jzxwMq"
       />
     </div>
   </div>
@@ -93,7 +89,7 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
   >
     <div>
       <div
-        class="sc-fzpjYC fZFmJB"
+        class="sc-fzoXzr jzxwMq"
       >
         <div
           class="sc-AxgMl fOrrlo"
@@ -114,21 +110,17 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
               >
                 phoneNumber
               </label>
-              <div
-                class="sc-fzoXzr hEdSyY"
-              >
-                <input
-                  autocomplete="tel"
-                  class="sc-fznyAO eZfilo"
-                  data-testid="phone_number"
-                  id="phone_number"
-                  name="phone_number"
-                  placeholder="phoneNumber"
-                  required=""
-                  type="tel"
-                  value=""
-                />
-              </div>
+              <input
+                autocomplete="tel"
+                class="sc-fznyAO eZfilo"
+                data-testid="phone_number"
+                id="phone_number"
+                name="phone_number"
+                placeholder="phoneNumber"
+                required=""
+                type="tel"
+                value=""
+              />
             </div>
             <button
               class="sc-fzqNJr gWXXZS"
@@ -141,7 +133,7 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
         </div>
       </div>
       <div
-        class="sc-fzpjYC fZFmJB"
+        class="sc-fzoXzr jzxwMq"
       >
         <div>
           <form

--- a/tests/widgets/passwordless/__snapshots__/passwordlessWidget.test.js.snap
+++ b/tests/widgets/passwordless/__snapshots__/passwordlessWidget.test.js.snap
@@ -360,7 +360,7 @@ exports[`Snapshot passwordless sms 1`] = `
   margin: 0 auto;
 }
 
-.c7 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -384,18 +384,18 @@ exports[`Snapshot passwordless sms 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c7:focus {
+.c6:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c7:hover,
-.c7:active {
+.c6:hover,
+.c6:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c7[disabled] {
+.c6[disabled] {
   opacity: .65;
 }
 
@@ -413,7 +413,7 @@ exports[`Snapshot passwordless sms 1`] = `
   margin-bottom: 10px;
 }
 
-.c6 {
+.c5 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -433,41 +433,31 @@ exports[`Snapshot passwordless sms 1`] = `
   -webkit-appearance: none;
 }
 
-.c6:focus {
+.c5:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c6:disabled,
-.c6[readonly] {
+.c5:disabled,
+.c5[readonly] {
   background-color: #e9ecef;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #868e96;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c6::placeholder {
+.c5::placeholder {
   color: #868e96;
-}
-
-.c5 {
-  --PhoneInput-color--focus: #229955;
-  --PhoneInputCountrySelect-marginRight: 10px;
-  --PhoneInputCountrySelectArrow-marginLeft: var(--PhoneInputCountrySelect-marginRight);
-  --PhoneInputCountrySelectArrow-borderWidth: 2px;
-  --PhoneInputCountrySelectArrow-transform: rotate(45deg);
-  --PhoneInputCountrySelectArrow-width: 0.3em;
-  --PhoneInputCountryFlag-height: 20px;
 }
 
 <div>
@@ -493,24 +483,20 @@ exports[`Snapshot passwordless sms 1`] = `
           >
             phoneNumber
           </label>
-          <div
+          <input
+            autocomplete="tel"
             class="c5"
-          >
-            <input
-              autocomplete="tel"
-              class="c6"
-              data-testid="phone_number"
-              id="phone_number"
-              name="phone_number"
-              placeholder="phoneNumber"
-              required=""
-              type="tel"
-              value=""
-            />
-          </div>
+            data-testid="phone_number"
+            id="phone_number"
+            name="phone_number"
+            placeholder="phoneNumber"
+            required=""
+            type="tel"
+            value=""
+          />
         </div>
         <button
-          class="c7"
+          class="c6"
           data-testid="submit"
           type="submit"
         >

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
- * @reachfive/identity-ui - v1.30.0
- * Compiled Thu, 21 Nov 2024 18:52:39 UTC
+ * @reachfive/identity-ui - v1.30.1
+ * Compiled Thu, 28 Nov 2024 15:30:22 UTC
  *
  * Copyright (c) ReachFive.
  *


### PR DESCRIPTION
[CA-4412](https://reach5.atlassian.net/browse/CA-4412)

Il s'avère que le problème vient d'un problème dans l'injection des styles de base prédéfini par la lib react-phone-number-input.
Sur Safari, la variable CSS manquante rend le style calculé invalide là où sur Chrome elle semble juste être ignorée.

[CA-4412]: https://reach5.atlassian.net/browse/CA-4412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ