### PR TITLE
Upgrade styled-components to v5.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "@types/react-dom": "^18.3.0",
                 "@types/react-test-renderer": "^18.3.0",
                 "@types/react-transition-group": "^4.4.10",
-                "@types/styled-components": "^5.1.28",
+                "@types/styled-components": "^5.1.34",
                 "@types/validator": "^13.11.2",
                 "@typescript-eslint/eslint-plugin": "^6.5.0",
                 "@typescript-eslint/parser": "^6.5.0",
@@ -77,7 +77,7 @@
             "peerDependencies": {
                 "react": "^18.3.0",
                 "react-dom": "^18.3.0",
-                "styled-components": "5.1.1"
+                "styled-components": "^5.3.11"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -2101,30 +2101,34 @@
             }
         },
         "node_modules/@emotion/is-prop-valid": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-            "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+            "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@emotion/memoize": "0.7.4"
+                "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/memoize": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-            "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/stylis": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
             "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/unitless": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
             "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@esbuild/darwin-arm64": {
@@ -5351,6 +5355,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
             "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -12694,9 +12699,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -12922,21 +12927,25 @@
             }
         },
         "node_modules/styled-components": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.1.tgz",
-            "integrity": "sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==",
+            "version": "5.3.11",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+            "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/traverse": "^7.4.5",
-                "@emotion/is-prop-valid": "^0.8.8",
+                "@emotion/is-prop-valid": "^1.1.0",
                 "@emotion/stylis": "^0.8.4",
                 "@emotion/unitless": "^0.7.4",
-                "babel-plugin-styled-components": ">= 1",
+                "babel-plugin-styled-components": ">= 1.12.0",
                 "css-to-react-native": "^3.0.0",
                 "hoist-non-react-statics": "^3.0.0",
                 "shallowequal": "^1.1.0",
                 "supports-color": "^5.5.0"
+            },
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "peerDependencies": {
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "styled-components": "5.1.1"
+        "styled-components": "^5.3.11"
     },
     "devDependencies": {
         "@babel/core": "^7.23.2",
@@ -71,7 +71,7 @@
         "@types/react-dom": "^18.3.0",
         "@types/react-test-renderer": "^18.3.0",
         "@types/react-transition-group": "^4.4.10",
-        "@types/styled-components": "^5.1.28",
+        "@types/styled-components": "^5.1.34",
         "@types/validator": "^13.11.2",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "@typescript-eslint/parser": "^6.5.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ const plugins = [
         }
     }),
     nodeResolve({
+        browser: true,
         extensions: ['.jsx', '.js', '.json'],
         preferBuiltins: true
     }),

--- a/tests/widgets/auth/__snapshots__/authWidget.test.js.snap
+++ b/tests/widgets/auth/__snapshots__/authWidget.test.js.snap
@@ -12,22 +12,25 @@ exports[`Snapshot forgot password view default 1`] = `
 .c2 {
   text-align: center;
   margin-bottom: 10px;
+}
+
+.c3 {
   color: #495057;
 }
 
-.c8 {
+.c9 {
   text-align: center;
   margin-top: 15px;
   color: #495057;
 }
 
-.c9 {
+.c10 {
   color: #229955;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c9:hover {
+.c10:hover {
   color: #145a32;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -47,7 +50,7 @@ exports[`Snapshot forgot password view default 1`] = `
   margin: 0 auto;
 }
 
-.c7 {
+.c8 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -71,41 +74,41 @@ exports[`Snapshot forgot password view default 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c7:focus {
+.c8:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c7:hover,
-.c7:active {
+.c8:hover,
+.c8:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c7[disabled] {
+.c8[disabled] {
   opacity: .65;
 }
 
-.c3 {
+.c4 {
   position: relative;
 }
 
-.c5 {
+.c6 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c4 {
+.c5 {
   margin-bottom: 10px;
 }
 
-.c4 > label::after {
+.c5 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c6 {
+.c7 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -127,30 +130,30 @@ exports[`Snapshot forgot password view default 1`] = `
   appearance: none;
 }
 
-.c6:focus {
+.c7:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c6:disabled,
-.c6[readonly] {
+.c7:disabled,
+.c7[readonly] {
   background-color: #e9ecef;
 }
 
-.c6::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c6::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #868e96;
 }
 
-.c6:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c6::placeholder {
+.c7::placeholder {
   color: #868e96;
 }
 
@@ -164,27 +167,27 @@ exports[`Snapshot forgot password view default 1`] = `
       forgotPassword.title
     </div>
     <div
-      className="c2"
+      className="c2 c3"
     >
       forgotPassword.prompt
     </div>
     <form
-      className="c3"
+      className="c4"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c4"
+        className="c5"
         required={true}
       >
         <label
-          className="c5"
+          className="c6"
           htmlFor="email"
         >
           email
         </label>
         <input
-          className="c6"
+          className="c7"
           data-testid="email"
           id="email"
           name="email"
@@ -199,7 +202,7 @@ exports[`Snapshot forgot password view default 1`] = `
         />
       </div>
       <button
-        className="c7"
+        className="c8"
         data-testid="submit"
         disabled={false}
         type="submit"
@@ -208,10 +211,10 @@ exports[`Snapshot forgot password view default 1`] = `
       </button>
     </form>
     <div
-      className="c8"
+      className="c9"
     >
       <a
-        className="c9"
+        className="c10"
         href="#"
         onClick={[Function]}
       >
@@ -231,451 +234,7 @@ exports[`Snapshot login view default 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c14 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c12 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c13 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c13:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c13:hover,
-.c13:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c13[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
 .c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
-  margin-bottom: 10px;
-  text-align: right;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      login.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="identifier"
-        >
-          identifier
-        </label>
-        <input
-          autoComplete="username webauthn"
-          className="c10"
-          data-testid="identifier"
-          id="identifier"
-          name="identifier"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="identifier"
-          readOnly={false}
-          required={true}
-          title="identifier"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            autoComplete="current-password"
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-          href="#"
-          onClick={[Function]}
-        >
-          login.forgotPasswordLink
-        </a>
-      </div>
-      <button
-        className="c13"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        login.submitLabel
-      </button>
-    </form>
-    <div
-      className="c14"
-    >
-      <span>
-        login.signupLinkPrefix
-      </span>
-       
-      <a
-        className="c12"
-        href="#"
-        onClick={[Function]}
-      >
-        login.signupLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot login view inline social buttons 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -684,13 +243,13 @@ exports[`Snapshot login view inline social buttons 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -699,1303 +258,12 @@ exports[`Snapshot login view inline social buttons 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c14 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c12 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c13 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c13:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c13:hover,
-.c13:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c13[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-  height: 100%;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-  margin: 0 4px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-  margin: 0 4px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-  margin: 0 -4px;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
-  margin-bottom: 10px;
-  text-align: right;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      login.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="identifier"
-        >
-          identifier
-        </label>
-        <input
-          autoComplete="username webauthn"
-          className="c10"
-          data-testid="identifier"
-          id="identifier"
-          name="identifier"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="identifier"
-          readOnly={false}
-          required={true}
-          title="identifier"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            autoComplete="current-password"
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-          href="#"
-          onClick={[Function]}
-        >
-          login.forgotPasswordLink
-        </a>
-      </div>
-      <button
-        className="c13"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        login.submitLabel
-      </button>
-    </form>
-    <div
-      className="c14"
-    >
-      <span>
-        login.signupLinkPrefix
-      </span>
-       
-      <a
-        className="c12"
-        href="#"
-        onClick={[Function]}
-      >
-        login.signupLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot login view no forgot password 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c12 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c13 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c13:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c11 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c11:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c11:hover,
-.c11:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c11[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      login.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="identifier"
-        >
-          identifier
-        </label>
-        <input
-          autoComplete="username webauthn"
-          className="c10"
-          data-testid="identifier"
-          id="identifier"
-          name="identifier"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="identifier"
-          readOnly={false}
-          required={true}
-          title="identifier"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            autoComplete="current-password"
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <button
-        className="c11"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        login.submitLabel
-      </button>
-    </form>
-    <div
-      className="c12"
-    >
-      <span>
-        login.signupLinkPrefix
-      </span>
-       
-      <a
-        className="c13"
-        href="#"
-        onClick={[Function]}
-      >
-        login.signupLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot login view no signup 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c12 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c13 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c13:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c13:hover,
-.c13:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c13[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
-  margin-bottom: 10px;
-  text-align: right;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      login.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="identifier"
-        >
-          identifier
-        </label>
-        <input
-          autoComplete="username webauthn"
-          className="c10"
-          data-testid="identifier"
-          id="identifier"
-          name="identifier"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="identifier"
-          readOnly={false}
-          required={true}
-          title="identifier"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            autoComplete="current-password"
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-          href="#"
-          onClick={[Function]}
-        >
-          login.forgotPasswordLink
-        </a>
-      </div>
-      <button
-        className="c13"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        login.submitLabel
-      </button>
-    </form>
-  </div>
-</div>
-`;
-
-exports[`Snapshot login view with canShowPassword 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
@@ -2030,6 +298,86 @@ exports[`Snapshot login view with canShowPassword 1`] = `
   max-width: 400px;
   box-sizing: border-box;
   margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
 }
 
 .c14 {
@@ -2071,7 +419,7 @@ exports[`Snapshot login view with canShowPassword 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -2085,118 +433,37 @@ exports[`Snapshot login view with canShowPassword 1`] = `
   background-position: center center;
 }
 
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
 }
 
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -2218,42 +485,31 @@ exports[`Snapshot login view with canShowPassword 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
-}
-
-.c11 {
-  position: absolute;
-  top: 13px;
-  right: 10px;
-  cursor: pointer;
-  opacity: 0.6;
-  fill: #495057;
-  width: 14px;
-  height: 14px;
 }
 
 .c12 {
@@ -2274,12 +530,12 @@ exports[`Snapshot login view with canShowPassword 1`] = `
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -2288,12 +544,12 @@ exports[`Snapshot login view with canShowPassword 1`] = `
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -2303,30 +559,30 @@ exports[`Snapshot login view with canShowPassword 1`] = `
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="identifier"
         >
           identifier
         </label>
         <input
           autoComplete="username webauthn"
-          className="c10"
+          className="c11"
           data-testid="identifier"
           id="identifier"
           name="identifier"
@@ -2341,11 +597,11 @@ exports[`Snapshot login view with canShowPassword 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -2359,7 +615,7 @@ exports[`Snapshot login view with canShowPassword 1`] = `
         >
           <input
             autoComplete="current-password"
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -2370,11 +626,6 @@ exports[`Snapshot login view with canShowPassword 1`] = `
             title="password"
             type="password"
             value=""
-          />
-          <svg
-            className="c11"
-            data-testid="show-password-btn"
-            onClick={[Function]}
           />
         </div>
       </div>
@@ -2417,7 +668,7 @@ exports[`Snapshot login view with canShowPassword 1`] = `
 </div>
 `;
 
-exports[`Snapshot login view with remember me 1`] = `
+exports[`Snapshot login view inline social buttons 1`] = `
 .c1 {
   margin-bottom: 15px;
   text-align: center;
@@ -2426,7 +677,7 @@ exports[`Snapshot login view with remember me 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -2435,13 +686,13 @@ exports[`Snapshot login view with remember me 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -2450,29 +701,29 @@ exports[`Snapshot login view with remember me 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
 
-.c16 {
+.c15 {
   text-align: center;
   margin-top: 15px;
   color: #495057;
 }
 
-.c12 {
+.c13 {
   color: #229955;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12:hover {
+.c13:hover {
   color: #145a32;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2490,6 +741,1372 @@ exports[`Snapshot login view with remember me 1`] = `
   max-width: 400px;
   box-sizing: border-box;
   margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c14 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c14:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c14:hover,
+.c14:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c14[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+  height: 100%;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+  margin: 0 4px;
+}
+
+.c2 {
+  text-align: center;
+  margin: 0 -4px;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c12 {
+  margin-bottom: 10px;
+  text-align: right;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      login.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="identifier"
+        >
+          identifier
+        </label>
+        <input
+          autoComplete="username webauthn"
+          className="c11"
+          data-testid="identifier"
+          id="identifier"
+          name="identifier"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="identifier"
+          readOnly={false}
+          required={true}
+          title="identifier"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            autoComplete="current-password"
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="#"
+          onClick={[Function]}
+        >
+          login.forgotPasswordLink
+        </a>
+      </div>
+      <button
+        className="c14"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        login.submitLabel
+      </button>
+    </form>
+    <div
+      className="c15"
+    >
+      <span>
+        login.signupLinkPrefix
+      </span>
+       
+      <a
+        className="c13"
+        href="#"
+        onClick={[Function]}
+      >
+        login.signupLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot login view no forgot password 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c13 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c14 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c12 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c12:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c12:hover,
+.c12:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c12[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      login.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="identifier"
+        >
+          identifier
+        </label>
+        <input
+          autoComplete="username webauthn"
+          className="c11"
+          data-testid="identifier"
+          id="identifier"
+          name="identifier"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="identifier"
+          readOnly={false}
+          required={true}
+          title="identifier"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            autoComplete="current-password"
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <button
+        className="c12"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        login.submitLabel
+      </button>
+    </form>
+    <div
+      className="c13"
+    >
+      <span>
+        login.signupLinkPrefix
+      </span>
+       
+      <a
+        className="c14"
+        href="#"
+        onClick={[Function]}
+      >
+        login.signupLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot login view no signup 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c13 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c13:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c14 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c14:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c14:hover,
+.c14:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c14[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c12 {
+  margin-bottom: 10px;
+  text-align: right;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      login.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="identifier"
+        >
+          identifier
+        </label>
+        <input
+          autoComplete="username webauthn"
+          className="c11"
+          data-testid="identifier"
+          id="identifier"
+          name="identifier"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="identifier"
+          readOnly={false}
+          required={true}
+          title="identifier"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            autoComplete="current-password"
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="#"
+          onClick={[Function]}
+        >
+          login.forgotPasswordLink
+        </a>
+      </div>
+      <button
+        className="c14"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        login.submitLabel
+      </button>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`Snapshot login view with canShowPassword 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c16 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c14 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
 }
 
 .c15 {
@@ -2531,7 +2148,7 @@ exports[`Snapshot login view with remember me 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -2543,6 +2160,332 @@ exports[`Snapshot login view with remember me 1`] = `
   background-repeat: no-repeat;
   background-size: 20px 20px;
   background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c12 {
+  position: absolute;
+  top: 13px;
+  right: 10px;
+  cursor: pointer;
+  opacity: 0.6;
+  fill: #495057;
+  width: 14px;
+  height: 14px;
+}
+
+.c13 {
+  margin-bottom: 10px;
+  text-align: right;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      login.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="identifier"
+        >
+          identifier
+        </label>
+        <input
+          autoComplete="username webauthn"
+          className="c11"
+          data-testid="identifier"
+          id="identifier"
+          name="identifier"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="identifier"
+          readOnly={false}
+          required={true}
+          title="identifier"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            autoComplete="current-password"
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+          <svg
+            className="c12"
+            data-testid="show-password-btn"
+            onClick={[Function]}
+          />
+        </div>
+      </div>
+      <div
+        className="c13"
+      >
+        <a
+          className="c14"
+          href="#"
+          onClick={[Function]}
+        >
+          login.forgotPasswordLink
+        </a>
+      </div>
+      <button
+        className="c15"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        login.submitLabel
+      </button>
+    </form>
+    <div
+      className="c16"
+    >
+      <span>
+        login.signupLinkPrefix
+      </span>
+       
+      <a
+        className="c14"
+        href="#"
+        onClick={[Function]}
+      >
+        login.signupLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot login view with remember me 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c17 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c13 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c13:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
 }
 
 .c3 {
@@ -2567,10 +2510,6 @@ exports[`Snapshot login view with remember me 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c3:focus {
@@ -2589,7 +2528,7 @@ exports[`Snapshot login view with remember me 1`] = `
   opacity: .65;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -2611,52 +2550,108 @@ exports[`Snapshot login view with remember me 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c16 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c16:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c16:hover,
+.c16:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c16[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
 }
 
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -2678,52 +2673,52 @@ exports[`Snapshot login view with remember me 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
-.c14 {
+.c15 {
   padding-left: 20px;
   margin-bottom: 0;
   cursor: pointer;
   font-weight: normal;
 }
 
-.c14 > input {
+.c15 > input {
   position: absolute;
   margin-left: -20px;
   margin-top: 2px;
   line-height: normal;
 }
 
-.c13 {
+.c14 {
   margin-bottom: 10px;
 }
 
-.c11 {
+.c12 {
   margin-bottom: 10px;
   text-align: right;
   position: absolute;
@@ -2743,12 +2738,12 @@ exports[`Snapshot login view with remember me 1`] = `
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -2757,12 +2752,12 @@ exports[`Snapshot login view with remember me 1`] = `
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -2772,30 +2767,30 @@ exports[`Snapshot login view with remember me 1`] = `
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="identifier"
         >
           identifier
         </label>
         <input
           autoComplete="username webauthn"
-          className="c10"
+          className="c11"
           data-testid="identifier"
           id="identifier"
           name="identifier"
@@ -2810,11 +2805,11 @@ exports[`Snapshot login view with remember me 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -2828,7 +2823,7 @@ exports[`Snapshot login view with remember me 1`] = `
         >
           <input
             autoComplete="current-password"
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -2843,10 +2838,10 @@ exports[`Snapshot login view with remember me 1`] = `
         </div>
       </div>
       <div
-        className="c11"
+        className="c12"
       >
         <a
-          className="c12"
+          className="c13"
           href="#"
           onClick={[Function]}
         >
@@ -2854,10 +2849,10 @@ exports[`Snapshot login view with remember me 1`] = `
         </a>
       </div>
       <div
-        className="c13"
+        className="c14"
       >
         <label
-          className="c14"
+          className="c15"
         >
           <input
             checked={false}
@@ -2871,7 +2866,7 @@ exports[`Snapshot login view with remember me 1`] = `
         </label>
       </div>
       <button
-        className="c15"
+        className="c16"
         data-testid="submit"
         disabled={false}
         type="submit"
@@ -2880,14 +2875,14 @@ exports[`Snapshot login view with remember me 1`] = `
       </button>
     </form>
     <div
-      className="c16"
+      className="c17"
     >
       <span>
         login.signupLinkPrefix
       </span>
        
       <a
-        className="c12"
+        className="c13"
         href="#"
         onClick={[Function]}
       >
@@ -2907,514 +2902,7 @@ exports[`Snapshot signup view default 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c12 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c13 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c13:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c11 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c11:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c11:hover,
-.c11:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c11[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
 .c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="givenName"
-        >
-          givenName
-        </label>
-        <input
-          className="c10"
-          data-testid="givenName"
-          id="givenName"
-          name="givenName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="givenName"
-          readOnly={false}
-          required={true}
-          title="givenName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="familyName"
-        >
-          familyName
-        </label>
-        <input
-          className="c10"
-          data-testid="familyName"
-          id="familyName"
-          name="familyName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="familyName"
-          readOnly={false}
-          required={true}
-          title="familyName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="email"
-        >
-          email
-        </label>
-        <input
-          className="c10"
-          data-testid="email"
-          id="email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="email"
-          readOnly={false}
-          required={true}
-          title="email"
-          type="email"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="passwordConfirmation"
-        >
-          passwordConfirmation
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="passwordConfirmation"
-            id="passwordConfirmation"
-            name="passwordConfirmation"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="passwordConfirmation"
-            required={true}
-            title="passwordConfirmation"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <button
-        className="c11"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        signup.submitLabel
-      </button>
-    </form>
-    <div
-      className="c12"
-    >
-      <span>
-        signup.loginLinkPrefix
-      </span>
-       
-      <a
-        className="c13"
-        href="#"
-        onClick={[Function]}
-      >
-        signup.loginLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot signup view inline social buttons 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -3423,13 +2911,13 @@ exports[`Snapshot signup view inline social buttons 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -3438,989 +2926,12 @@ exports[`Snapshot signup view inline social buttons 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c12 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c13 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c13:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c11 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c11:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c11:hover,
-.c11:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c11[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-  height: 100%;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-  margin: 0 4px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-  margin: 0 4px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-  margin: 0 -4px;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="givenName"
-        >
-          givenName
-        </label>
-        <input
-          className="c10"
-          data-testid="givenName"
-          id="givenName"
-          name="givenName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="givenName"
-          readOnly={false}
-          required={true}
-          title="givenName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="familyName"
-        >
-          familyName
-        </label>
-        <input
-          className="c10"
-          data-testid="familyName"
-          id="familyName"
-          name="familyName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="familyName"
-          readOnly={false}
-          required={true}
-          title="familyName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="email"
-        >
-          email
-        </label>
-        <input
-          className="c10"
-          data-testid="email"
-          id="email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="email"
-          readOnly={false}
-          required={true}
-          title="email"
-          type="email"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="passwordConfirmation"
-        >
-          passwordConfirmation
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="passwordConfirmation"
-            id="passwordConfirmation"
-            name="passwordConfirmation"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="passwordConfirmation"
-            required={true}
-            title="passwordConfirmation"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <button
-        className="c11"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        signup.submitLabel
-      </button>
-    </form>
-    <div
-      className="c12"
-    >
-      <span>
-        signup.loginLinkPrefix
-      </span>
-       
-      <a
-        className="c13"
-        href="#"
-        onClick={[Function]}
-      >
-        signup.loginLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot signup view no login 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c11 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c11:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c11:hover,
-.c11:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c11[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="givenName"
-        >
-          givenName
-        </label>
-        <input
-          className="c10"
-          data-testid="givenName"
-          id="givenName"
-          name="givenName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="givenName"
-          readOnly={false}
-          required={true}
-          title="givenName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="familyName"
-        >
-          familyName
-        </label>
-        <input
-          className="c10"
-          data-testid="familyName"
-          id="familyName"
-          name="familyName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="familyName"
-          readOnly={false}
-          required={true}
-          title="familyName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="email"
-        >
-          email
-        </label>
-        <input
-          className="c10"
-          data-testid="email"
-          id="email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="email"
-          readOnly={false}
-          required={true}
-          title="email"
-          type="email"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="passwordConfirmation"
-        >
-          passwordConfirmation
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="passwordConfirmation"
-            id="passwordConfirmation"
-            name="passwordConfirmation"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="passwordConfirmation"
-            required={true}
-            title="passwordConfirmation"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <button
-        className="c11"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        signup.submitLabel
-      </button>
-    </form>
-  </div>
-</div>
-`;
-
-exports[`Snapshot signup view show labels 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
@@ -4457,7 +2968,87 @@ exports[`Snapshot signup view show labels 1`] = `
   margin: 0 auto;
 }
 
-.c11 {
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c12 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -4481,22 +3072,22 @@ exports[`Snapshot signup view show labels 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c11:hover,
-.c11:active {
+.c12:hover,
+.c12:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c11[disabled] {
+.c12[disabled] {
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -4508,6 +3099,379 @@ exports[`Snapshot signup view show labels 1`] = `
   background-repeat: no-repeat;
   background-size: 20px 20px;
   background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="givenName"
+        >
+          givenName
+        </label>
+        <input
+          className="c11"
+          data-testid="givenName"
+          id="givenName"
+          name="givenName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="givenName"
+          readOnly={false}
+          required={true}
+          title="givenName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="familyName"
+        >
+          familyName
+        </label>
+        <input
+          className="c11"
+          data-testid="familyName"
+          id="familyName"
+          name="familyName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="familyName"
+          readOnly={false}
+          required={true}
+          title="familyName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="email"
+        >
+          email
+        </label>
+        <input
+          className="c11"
+          data-testid="email"
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="email"
+          readOnly={false}
+          required={true}
+          title="email"
+          type="email"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="passwordConfirmation"
+        >
+          passwordConfirmation
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="passwordConfirmation"
+            id="passwordConfirmation"
+            name="passwordConfirmation"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="passwordConfirmation"
+            required={true}
+            title="passwordConfirmation"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <button
+        className="c12"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        signup.submitLabel
+      </button>
+    </form>
+    <div
+      className="c13"
+    >
+      <span>
+        signup.loginLinkPrefix
+      </span>
+       
+      <a
+        className="c14"
+        href="#"
+        onClick={[Function]}
+      >
+        signup.loginLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot signup view inline social buttons 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c13 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c14 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
 }
 
 .c3 {
@@ -4532,10 +3496,6 @@ exports[`Snapshot signup view show labels 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c3:focus {
@@ -4554,7 +3514,7 @@ exports[`Snapshot signup view show labels 1`] = `
   opacity: .65;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -4576,59 +3536,112 @@ exports[`Snapshot signup view show labels 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(0,0,0,0);
 }
 
-.c5:hover,
-.c5:active {
+.c6:hover,
+.c6:active {
   color: #58666e;
   background-color: #ebebeb;
   border-color: rgba(0,0,0,0.15);
 }
 
-.c5[disabled] {
+.c6[disabled] {
   opacity: .65;
+}
+
+.c12 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c12:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c12:hover,
+.c12:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c12[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+  height: 100%;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+  margin: 0 4px;
 }
 
 .c2 {
   text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c12 {
-  color: #adb5bd;
-  display: block;
-  padding: 9px 12px;
-  text-align: center;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: inline-block;
+  margin: 0 -4px;
 }
 
 .c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -4650,30 +3663,30 @@ exports[`Snapshot signup view show labels 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
@@ -4690,58 +3703,48 @@ exports[`Snapshot signup view show labels 1`] = `
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="givenName"
         >
           givenName
         </label>
         <input
-          className="c10"
+          className="c11"
           data-testid="givenName"
           id="givenName"
           name="givenName"
@@ -4755,17 +3758,17 @@ exports[`Snapshot signup view show labels 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="familyName"
         >
           familyName
         </label>
         <input
-          className="c10"
+          className="c11"
           data-testid="familyName"
           id="familyName"
           name="familyName"
@@ -4779,17 +3782,17 @@ exports[`Snapshot signup view show labels 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="email"
         >
           email
         </label>
         <input
-          className="c10"
+          className="c11"
           data-testid="email"
           id="email"
           name="email"
@@ -4804,11 +3807,11 @@ exports[`Snapshot signup view show labels 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -4821,7 +3824,7 @@ exports[`Snapshot signup view show labels 1`] = `
           }
         >
           <input
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -4837,11 +3840,11 @@ exports[`Snapshot signup view show labels 1`] = `
         </div>
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="passwordConfirmation"
         >
           passwordConfirmation
@@ -4854,7 +3857,7 @@ exports[`Snapshot signup view show labels 1`] = `
           }
         >
           <input
-            className="c10"
+            className="c11"
             data-testid="passwordConfirmation"
             id="passwordConfirmation"
             name="passwordConfirmation"
@@ -4869,19 +3872,13 @@ exports[`Snapshot signup view show labels 1`] = `
         </div>
       </div>
       <button
-        className="c11"
+        className="c12"
         data-testid="submit"
         disabled={false}
         type="submit"
       >
         signup.submitLabel
       </button>
-      <span
-        className="c12"
-      >
-        *
-        form.required.fields
-      </span>
     </form>
     <div
       className="c13"
@@ -4902,7 +3899,7 @@ exports[`Snapshot signup view show labels 1`] = `
 </div>
 `;
 
-exports[`Snapshot signup view with consents 1`] = `
+exports[`Snapshot signup view no login 1`] = `
 .c1 {
   margin-bottom: 15px;
   text-align: center;
@@ -4911,7 +3908,7 @@ exports[`Snapshot signup view with consents 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -4920,13 +3917,13 @@ exports[`Snapshot signup view with consents 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -4935,12 +3932,489 @@ exports[`Snapshot signup view with consents 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c12 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c12:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c12:hover,
+.c12:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c12[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="givenName"
+        >
+          givenName
+        </label>
+        <input
+          className="c11"
+          data-testid="givenName"
+          id="givenName"
+          name="givenName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="givenName"
+          readOnly={false}
+          required={true}
+          title="givenName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="familyName"
+        >
+          familyName
+        </label>
+        <input
+          className="c11"
+          data-testid="familyName"
+          id="familyName"
+          name="familyName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="familyName"
+          readOnly={false}
+          required={true}
+          title="familyName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="email"
+        >
+          email
+        </label>
+        <input
+          className="c11"
+          data-testid="email"
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="email"
+          readOnly={false}
+          required={true}
+          title="email"
+          type="email"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="passwordConfirmation"
+        >
+          passwordConfirmation
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="passwordConfirmation"
+            id="passwordConfirmation"
+            name="passwordConfirmation"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="passwordConfirmation"
+            required={true}
+            title="passwordConfirmation"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <button
+        className="c12"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        signup.submitLabel
+      </button>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`Snapshot signup view show labels 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c13 {
+  color: #adb5bd;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
@@ -4975,6 +4449,1097 @@ exports[`Snapshot signup view with consents 1`] = `
   max-width: 400px;
   box-sizing: border-box;
   margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c12 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c12:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c12:hover,
+.c12:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c12[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c14 {
+  display: block;
+  padding: 9px 12px;
+  text-align: center;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: inline-block;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="givenName"
+        >
+          givenName
+        </label>
+        <input
+          className="c11"
+          data-testid="givenName"
+          id="givenName"
+          name="givenName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="givenName"
+          readOnly={false}
+          required={true}
+          title="givenName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="familyName"
+        >
+          familyName
+        </label>
+        <input
+          className="c11"
+          data-testid="familyName"
+          id="familyName"
+          name="familyName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="familyName"
+          readOnly={false}
+          required={true}
+          title="familyName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="email"
+        >
+          email
+        </label>
+        <input
+          className="c11"
+          data-testid="email"
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="email"
+          readOnly={false}
+          required={true}
+          title="email"
+          type="email"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="passwordConfirmation"
+        >
+          passwordConfirmation
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="passwordConfirmation"
+            id="passwordConfirmation"
+            name="passwordConfirmation"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="passwordConfirmation"
+            required={true}
+            title="passwordConfirmation"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <button
+        className="c12"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        signup.submitLabel
+      </button>
+      <span
+        className="c13 c14"
+      >
+        *
+        form.required.fields
+      </span>
+    </form>
+    <div
+      className="c15"
+    >
+      <span>
+        signup.loginLinkPrefix
+      </span>
+       
+      <a
+        className="c16"
+        href="#"
+        onClick={[Function]}
+      >
+        signup.loginLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot signup view with consents 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c16 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c17 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c15 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c15:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c15:hover,
+.c15:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c15[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c13 {
+  padding-left: 20px;
+  margin-bottom: 0;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.c13 > input {
+  position: absolute;
+  margin-left: -20px;
+  margin-top: 2px;
+  line-height: normal;
+}
+
+.c12 {
+  margin-bottom: 10px;
+}
+
+.c14 {
+  font-size: 12px;
+  color: #adb5bd;
+  margin: 5px 5px 10px 5px;
+  text-align: justify;
+  display: block;
+}
+
+.c14 > p {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="email"
+        >
+          email
+        </label>
+        <input
+          className="c11"
+          data-testid="email"
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="email"
+          readOnly={false}
+          required={true}
+          title="email"
+          type="email"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        style={
+          {
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          className="c12"
+        >
+          <label
+            className="c13"
+          >
+            <input
+              checked={false}
+              data-testid="consents.aConsent.1"
+              name="consents.aConsent.1"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            consent title
+          </label>
+        </div>
+        <div
+          className="c14"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<p>consent description</p>
+",
+            }
+          }
+          data-testid="consents.aConsent.1.description"
+          data-text="md"
+        />
+      </div>
+      <button
+        className="c15"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        signup.submitLabel
+      </button>
+    </form>
+    <div
+      className="c16"
+    >
+      <span>
+        signup.loginLinkPrefix
+      </span>
+       
+      <a
+        className="c17"
+        href="#"
+        onClick={[Function]}
+      >
+        signup.loginLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot signup view with custom fields 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c15 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c16 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c16:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
 }
 
 .c14 {
@@ -5016,7 +5581,7 @@ exports[`Snapshot signup view with consents 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -5030,118 +5595,37 @@ exports[`Snapshot signup view with consents 1`] = `
   background-position: center center;
 }
 
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
 }
 
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -5163,62 +5647,49 @@ exports[`Snapshot signup view with consents 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
-.c12 {
+.c13 {
   padding-left: 20px;
   margin-bottom: 0;
   cursor: pointer;
   font-weight: normal;
 }
 
-.c12 > input {
+.c13 > input {
   position: absolute;
   margin-left: -20px;
   margin-top: 2px;
   line-height: normal;
 }
 
-.c11 {
+.c12 {
   margin-bottom: 10px;
-}
-
-.c13 {
-  font-size: 12px;
-  color: #adb5bd;
-  margin: 5px 5px 10px 5px;
-  text-align: justify;
-  display: block;
-}
-
-.c13 > p {
-  margin-top: 1px;
-  margin-bottom: 1px;
 }
 
 <div
@@ -5234,12 +5705,12 @@ exports[`Snapshot signup view with consents 1`] = `
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -5248,12 +5719,12 @@ exports[`Snapshot signup view with consents 1`] = `
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -5263,29 +5734,29 @@ exports[`Snapshot signup view with consents 1`] = `
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="email"
         >
           email
         </label>
         <input
-          className="c10"
+          className="c11"
           data-testid="email"
           id="email"
           name="email"
@@ -5300,11 +5771,11 @@ exports[`Snapshot signup view with consents 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -5317,7 +5788,7 @@ exports[`Snapshot signup view with consents 1`] = `
           }
         >
           <input
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -5333,40 +5804,21 @@ exports[`Snapshot signup view with consents 1`] = `
         </div>
       </div>
       <div
-        style={
-          {
-            "position": "relative",
-          }
-        }
+        className="c12"
       >
-        <div
-          className="c11"
-        >
-          <label
-            className="c12"
-          >
-            <input
-              checked={false}
-              data-testid="consents.aConsent.1"
-              name="consents.aConsent.1"
-              onChange={[Function]}
-              required={false}
-              type="checkbox"
-            />
-            consent title
-          </label>
-        </div>
-        <div
+        <label
           className="c13"
-          dangerouslySetInnerHTML={
-            {
-              "__html": "<p>consent description</p>
-",
-            }
-          }
-          data-testid="consents.aConsent.1.description"
-          data-text="md"
-        />
+        >
+          <input
+            checked={false}
+            data-testid="custom_fields.newsletter_optin"
+            name="custom_fields.newsletter_optin"
+            onChange={[Function]}
+            required={true}
+            type="checkbox"
+          />
+          Newsletter optin
+        </label>
       </div>
       <button
         className="c14"
@@ -5396,7 +5848,7 @@ exports[`Snapshot signup view with consents 1`] = `
 </div>
 `;
 
-exports[`Snapshot signup view with custom fields 1`] = `
+exports[`Snapshot signup view with mandatory consents 1`] = `
 .c1 {
   margin-bottom: 15px;
   text-align: center;
@@ -5405,7 +5857,7 @@ exports[`Snapshot signup view with custom fields 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -5414,13 +5866,13 @@ exports[`Snapshot signup view with custom fields 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -5429,12 +5881,505 @@ exports[`Snapshot signup view with custom fields 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c16 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c17 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c15 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c15:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c15:hover,
+.c15:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c15[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c13 {
+  padding-left: 20px;
+  margin-bottom: 0;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.c13 > input {
+  position: absolute;
+  margin-left: -20px;
+  margin-top: 2px;
+  line-height: normal;
+}
+
+.c12 {
+  margin-bottom: 10px;
+}
+
+.c14 {
+  font-size: 12px;
+  color: #adb5bd;
+  margin: 5px 5px 10px 5px;
+  text-align: justify;
+  display: block;
+}
+
+.c14 > p {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="email"
+        >
+          email
+        </label>
+        <input
+          className="c11"
+          data-testid="email"
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="email"
+          readOnly={false}
+          required={true}
+          title="email"
+          type="email"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        style={
+          {
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          className="c12"
+        >
+          <label
+            className="c13"
+          >
+            <input
+              checked={false}
+              data-testid="consents.aConsent.1"
+              name="consents.aConsent.1"
+              onChange={[Function]}
+              required={true}
+              type="checkbox"
+            />
+            consent title
+          </label>
+        </div>
+        <div
+          className="c14"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<p>consent description</p>
+",
+            }
+          }
+          data-testid="consents.aConsent.1.description"
+          data-text="md"
+        />
+      </div>
+      <button
+        className="c15"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        signup.submitLabel
+      </button>
+    </form>
+    <div
+      className="c16"
+    >
+      <span>
+        signup.loginLinkPrefix
+      </span>
+       
+      <a
+        className="c17"
+        href="#"
+        onClick={[Function]}
+      >
+        signup.loginLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot signup view with user agreement 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
@@ -5471,6 +6416,86 @@ exports[`Snapshot signup view with custom fields 1`] = `
   margin: 0 auto;
 }
 
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
 .c13 {
   display: block;
   width: 100%;
@@ -5510,7 +6535,7 @@ exports[`Snapshot signup view with custom fields 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -5524,118 +6549,37 @@ exports[`Snapshot signup view with custom fields 1`] = `
   background-position: center center;
 }
 
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
 }
 
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -5657,49 +6601,52 @@ exports[`Snapshot signup view with custom fields 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
 .c12 {
-  padding-left: 20px;
-  margin-bottom: 0;
-  cursor: pointer;
-  font-weight: normal;
-}
-
-.c12 > input {
-  position: absolute;
-  margin-left: -20px;
-  margin-top: 2px;
-  line-height: normal;
-}
-
-.c11 {
+  font-size: 11.200000000000001px;
+  color: #adb5bd;
+  text-align: center;
   margin-bottom: 10px;
+}
+
+.c12 p {
+  margin: 0;
+}
+
+.c12 a {
+  color: #adb5bd;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c12 a:hover {
+  color: #adb5bd;
 }
 
 <div
@@ -5715,12 +6662,12 @@ exports[`Snapshot signup view with custom fields 1`] = `
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -5729,12 +6676,12 @@ exports[`Snapshot signup view with custom fields 1`] = `
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -5744,29 +6691,77 @@ exports[`Snapshot signup view with custom fields 1`] = `
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
+          htmlFor="givenName"
+        >
+          givenName
+        </label>
+        <input
+          className="c11"
+          data-testid="givenName"
+          id="givenName"
+          name="givenName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="givenName"
+          readOnly={false}
+          required={true}
+          title="givenName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="familyName"
+        >
+          familyName
+        </label>
+        <input
+          className="c11"
+          data-testid="familyName"
+          id="familyName"
+          name="familyName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="familyName"
+          readOnly={false}
+          required={true}
+          title="familyName"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
           htmlFor="email"
         >
           email
         </label>
         <input
-          className="c10"
+          className="c11"
           data-testid="email"
           id="email"
           name="email"
@@ -5781,11 +6776,11 @@ exports[`Snapshot signup view with custom fields 1`] = `
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -5798,7 +6793,7 @@ exports[`Snapshot signup view with custom fields 1`] = `
           }
         >
           <input
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -5814,22 +6809,48 @@ exports[`Snapshot signup view with custom fields 1`] = `
         </div>
       </div>
       <div
-        className="c11"
+        className="c9"
+        required={true}
       >
         <label
-          className="c12"
+          className="c10"
+          htmlFor="passwordConfirmation"
+        >
+          passwordConfirmation
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
         >
           <input
-            checked={false}
-            data-testid="custom_fields.newsletter_optin"
-            name="custom_fields.newsletter_optin"
+            className="c11"
+            data-testid="passwordConfirmation"
+            id="passwordConfirmation"
+            name="passwordConfirmation"
+            onBlur={[Function]}
             onChange={[Function]}
+            placeholder="passwordConfirmation"
             required={true}
-            type="checkbox"
+            title="passwordConfirmation"
+            type="password"
+            value=""
           />
-          Newsletter optin
-        </label>
+        </div>
       </div>
+      <div
+        className="c12"
+        dangerouslySetInnerHTML={
+          {
+            "__html": "<p>En vous inscrivant, vous acceptez les <a href="https://sandbox-local.reach5.co/" target="_blank" rel="nofollow noreferrer noopener">conditions générales d'utilisation</a>.</p>
+",
+          }
+        }
+        data-testid="user-aggreement"
+        data-text="md"
+      />
       <button
         className="c13"
         data-testid="submit"
@@ -5858,7 +6879,7 @@ exports[`Snapshot signup view with custom fields 1`] = `
 </div>
 `;
 
-exports[`Snapshot signup view with mandatory consents 1`] = `
+exports[`Snapshot with webauthn feature and without password login new view with integrated webauthn and password 1`] = `
 .c1 {
   margin-bottom: 15px;
   text-align: center;
@@ -5867,7 +6888,7 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -5876,13 +6897,13 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -5891,12 +6912,12 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
@@ -5907,13 +6928,13 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   color: #495057;
 }
 
-.c16 {
+.c13 {
   color: #229955;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c16:hover {
+.c13:hover {
   color: #145a32;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5931,6 +6952,86 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   max-width: 400px;
   box-sizing: border-box;
   margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
 }
 
 .c14 {
@@ -5972,7 +7073,7 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -5986,118 +7087,37 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   background-position: center center;
 }
 
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
 }
 
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -6119,1067 +7139,34 @@ exports[`Snapshot signup view with mandatory consents 1`] = `
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
 .c12 {
-  padding-left: 20px;
-  margin-bottom: 0;
-  cursor: pointer;
-  font-weight: normal;
-}
-
-.c12 > input {
-  position: absolute;
-  margin-left: -20px;
-  margin-top: 2px;
-  line-height: normal;
-}
-
-.c11 {
-  margin-bottom: 10px;
-}
-
-.c13 {
-  font-size: 12px;
-  color: #adb5bd;
-  margin: 5px 5px 10px 5px;
-  text-align: justify;
-  display: block;
-}
-
-.c13 > p {
-  margin-top: 1px;
-  margin-bottom: 1px;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="email"
-        >
-          email
-        </label>
-        <input
-          className="c10"
-          data-testid="email"
-          id="email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="email"
-          readOnly={false}
-          required={true}
-          title="email"
-          type="email"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        style={
-          {
-            "position": "relative",
-          }
-        }
-      >
-        <div
-          className="c11"
-        >
-          <label
-            className="c12"
-          >
-            <input
-              checked={false}
-              data-testid="consents.aConsent.1"
-              name="consents.aConsent.1"
-              onChange={[Function]}
-              required={true}
-              type="checkbox"
-            />
-            consent title
-          </label>
-        </div>
-        <div
-          className="c13"
-          dangerouslySetInnerHTML={
-            {
-              "__html": "<p>consent description</p>
-",
-            }
-          }
-          data-testid="consents.aConsent.1.description"
-          data-text="md"
-        />
-      </div>
-      <button
-        className="c14"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        signup.submitLabel
-      </button>
-    </form>
-    <div
-      className="c15"
-    >
-      <span>
-        signup.loginLinkPrefix
-      </span>
-       
-      <a
-        className="c16"
-        href="#"
-        onClick={[Function]}
-      >
-        signup.loginLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot signup view with user agreement 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c13 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c14 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c14:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c12 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c12:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c12:hover,
-.c12:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c12[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
-  font-size: 11.200000000000001px;
-  color: #adb5bd;
-  text-align: center;
-  margin-bottom: 10px;
-}
-
-.c11 p {
-  margin: 0;
-}
-
-.c11 a {
-  color: #adb5bd;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c11 a:hover {
-  color: #adb5bd;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="givenName"
-        >
-          givenName
-        </label>
-        <input
-          className="c10"
-          data-testid="givenName"
-          id="givenName"
-          name="givenName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="givenName"
-          readOnly={false}
-          required={true}
-          title="givenName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="familyName"
-        >
-          familyName
-        </label>
-        <input
-          className="c10"
-          data-testid="familyName"
-          id="familyName"
-          name="familyName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="familyName"
-          readOnly={false}
-          required={true}
-          title="familyName"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="email"
-        >
-          email
-        </label>
-        <input
-          className="c10"
-          data-testid="email"
-          id="email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="email"
-          readOnly={false}
-          required={true}
-          title="email"
-          type="email"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="passwordConfirmation"
-        >
-          passwordConfirmation
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            className="c10"
-            data-testid="passwordConfirmation"
-            id="passwordConfirmation"
-            name="passwordConfirmation"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="passwordConfirmation"
-            required={true}
-            title="passwordConfirmation"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c11"
-        dangerouslySetInnerHTML={
-          {
-            "__html": "<p>En vous inscrivant, vous acceptez les <a href="https://sandbox-local.reach5.co/" target="_blank" rel="nofollow noreferrer noopener">conditions générales d'utilisation</a>.</p>
-",
-          }
-        }
-        data-testid="user-aggreement"
-        data-text="md"
-      />
-      <button
-        className="c12"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        signup.submitLabel
-      </button>
-    </form>
-    <div
-      className="c13"
-    >
-      <span>
-        signup.loginLinkPrefix
-      </span>
-       
-      <a
-        className="c14"
-        href="#"
-        onClick={[Function]}
-      >
-        signup.loginLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot with webauthn feature and without password login new view with integrated webauthn and password 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c14 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c12 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c13 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c13:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c13:hover,
-.c13:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c13[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
   margin-bottom: 10px;
   text-align: right;
 }
@@ -7197,12 +7184,12 @@ exports[`Snapshot with webauthn feature and without password login new view with
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -7211,12 +7198,12 @@ exports[`Snapshot with webauthn feature and without password login new view with
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -7226,30 +7213,30 @@ exports[`Snapshot with webauthn feature and without password login new view with
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="identifier"
         >
           identifier
         </label>
         <input
           autoComplete="username webauthn"
-          className="c10"
+          className="c11"
           data-testid="identifier"
           id="identifier"
           name="identifier"
@@ -7264,11 +7251,11 @@ exports[`Snapshot with webauthn feature and without password login new view with
         />
       </div>
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="password"
         >
           password
@@ -7282,7 +7269,7 @@ exports[`Snapshot with webauthn feature and without password login new view with
         >
           <input
             autoComplete="current-password"
-            className="c10"
+            className="c11"
             data-testid="password"
             id="password"
             name="password"
@@ -7297,10 +7284,10 @@ exports[`Snapshot with webauthn feature and without password login new view with
         </div>
       </div>
       <div
-        className="c11"
+        className="c12"
       >
         <a
-          className="c12"
+          className="c13"
           href="#"
           onClick={[Function]}
         >
@@ -7308,7 +7295,7 @@ exports[`Snapshot with webauthn feature and without password login new view with
         </a>
       </div>
       <button
-        className="c13"
+        className="c14"
         data-testid="submit"
         disabled={false}
         type="submit"
@@ -7317,14 +7304,14 @@ exports[`Snapshot with webauthn feature and without password login new view with
       </button>
     </form>
     <div
-      className="c14"
+      className="c15"
     >
       <span>
         login.signupLinkPrefix
       </span>
        
       <a
-        className="c12"
+        className="c13"
         href="#"
         onClick={[Function]}
       >
@@ -7344,7 +7331,7 @@ exports[`Snapshot with webauthn feature and without password login old view with
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -7353,13 +7340,13 @@ exports[`Snapshot with webauthn feature and without password login old view with
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -7368,29 +7355,29 @@ exports[`Snapshot with webauthn feature and without password login old view with
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
 
-.c15 {
+.c16 {
   text-align: center;
   margin-top: 15px;
   color: #495057;
 }
 
-.c16 {
+.c17 {
   color: #229955;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c16:hover {
+.c17:hover {
   color: #145a32;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7410,7 +7397,87 @@ exports[`Snapshot with webauthn feature and without password login old view with
   margin: 0 auto;
 }
 
-.c12 {
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c13 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -7434,23 +7501,23 @@ exports[`Snapshot with webauthn feature and without password login old view with
   transition: all .15s ease-in-out;
 }
 
-.c12:focus {
+.c13:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
 }
 
-.c12:hover,
-.c12:active {
+.c13:hover,
+.c13:active {
   color: #229955;
   background-color: #ebebeb;
   border-color: #ebebeb;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -7464,118 +7531,37 @@ exports[`Snapshot with webauthn feature and without password login old view with
   background-position: center center;
 }
 
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
 }
 
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -7597,39 +7583,39 @@ exports[`Snapshot with webauthn feature and without password login old view with
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
-.c14 {
+.c15 {
   width: 40px;
   height: 40px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7644,12 +7630,12 @@ exports[`Snapshot with webauthn feature and without password login old view with
   justify-content: center;
 }
 
-.c13 .r5-button-text {
+.c14 .r5-button-text {
   margin-left: 10px;
   text-transform: uppercase;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7660,7 +7646,7 @@ exports[`Snapshot with webauthn feature and without password login old view with
   align-items: center;
 }
 
-.c11 > :not(:last-child) {
+.c12 > :not(:last-child) {
   margin-right: 20px;
 }
 
@@ -7677,12 +7663,12 @@ exports[`Snapshot with webauthn feature and without password login old view with
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -7691,12 +7677,12 @@ exports[`Snapshot with webauthn feature and without password login old view with
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -7706,30 +7692,30 @@ exports[`Snapshot with webauthn feature and without password login old view with
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="identifier"
         >
           identifier
         </label>
         <input
           autoComplete="username webauthn"
-          className="c10"
+          className="c11"
           data-testid="identifier"
           id="identifier"
           name="identifier"
@@ -7744,30 +7730,30 @@ exports[`Snapshot with webauthn feature and without password login old view with
         />
       </div>
       <div
-        className="r5-webauthn-login-buttons c11"
+        className="r5-webauthn-login-buttons c12"
       >
         <button
-          className="c12 r5-button-with-icon c13"
+          className="c13 r5-button-with-icon c14"
           data-testid="webauthn-button"
           disabled={false}
           title="login.withBiometrics"
           type="submit"
         >
           <svg
-            className="c14"
+            className="c15"
           />
         </button>
       </div>
     </form>
     <div
-      className="c15"
+      className="c16"
     >
       <span>
         login.signupLinkPrefix
       </span>
        
       <a
-        className="c16"
+        className="c17"
         href="#"
         onClick={[Function]}
       >
@@ -8629,7 +8615,7 @@ exports[`Snapshot with webauthn feature and without password signup view with we
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -8638,13 +8624,13 @@ exports[`Snapshot with webauthn feature and without password signup view with we
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -8653,351 +8639,17 @@ exports[`Snapshot with webauthn feature and without password signup view with we
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
-}
-
-.c10 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
 }
 
 .c11 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c11:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c7 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #229955;
-  background-color: #ffffff;
-  border: 1px solid #ffffff;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c7:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
-}
-
-.c7:hover,
-.c7:active {
-  color: #229955;
-  background-color: #ebebeb;
-  border-color: #ebebeb;
-}
-
-.c7[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
-.c3 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #3b5998;
-  border: 1px solid #3b5998;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c3:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
-}
-
-.c3:hover,
-.c3:active {
-  color: #ffffff;
-  background-color: #30487b;
-  border-color: #30487b;
-}
-
-.c3[disabled] {
-  opacity: .65;
-}
-
-.c5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #58666e;
-  background-color: #ffffff;
-  border: 1px solid rgba(0,0,0,.15);
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
-}
-
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
-.c2 {
-  text-align: center;
-}
-
-.c9 {
-  width: 40px;
-  height: 40px;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c8 .r5-button-text {
-  margin-left: 10px;
-  text-transform: uppercase;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      signup.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <div
-      className="r5-webauthn-signup-buttons "
-    >
-      <button
-        className="c7 r5-button-with-icon c8"
-        data-testid="webauthn-button"
-        disabled={false}
-        onClick={[Function]}
-        title="signup.withBiometrics"
-        type="submit"
-      >
-        <svg
-          className="c9"
-        />
-        <span
-          className="r5-button-text"
-        >
-          biometrics
-        </span>
-      </button>
-    </div>
-    <div
-      className="c10"
-    >
-      <span>
-        signup.loginLinkPrefix
-      </span>
-       
-      <a
-        className="c11"
-        href="#"
-        onClick={[Function]}
-      >
-        signup.loginLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot with webauthn feature login new view with integradted webauthn and password 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c14 {
   text-align: center;
   margin-top: 15px;
   color: #495057;
@@ -9029,59 +8681,6 @@ exports[`Snapshot with webauthn feature login new view with integradted webauthn
   margin: 0 auto;
 }
 
-.c13 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #229955;
-  border: 1px solid #229955;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c13:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
-}
-
-.c13:hover,
-.c13:active {
-  background-color: #1b7842;
-  border-color: #1b7842;
-}
-
-.c13[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
 .c3 {
   display: block;
   width: 100%;
@@ -9104,10 +8703,6 @@ exports[`Snapshot with webauthn feature login new view with integradted webauthn
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c3:focus {
@@ -9126,7 +8721,7 @@ exports[`Snapshot with webauthn feature login new view with integradted webauthn
   opacity: .65;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -9148,332 +8743,25 @@ exports[`Snapshot with webauthn feature login new view with integradted webauthn
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(0,0,0,0);
 }
 
-.c5:hover,
-.c5:active {
+.c6:hover,
+.c6:active {
   color: #58666e;
   background-color: #ebebeb;
   border-color: rgba(0,0,0,0.15);
 }
 
-.c5[disabled] {
+.c6[disabled] {
   opacity: .65;
 }
 
-.c2 {
-  text-align: center;
-}
-
-.c7 {
-  position: relative;
-}
-
-.c9 {
-  color: #495057;
-  margin-bottom: 5px;
-  display: none;
-}
-
 .c8 {
-  margin-bottom: 10px;
-}
-
-.c8 > label::after {
-  content: "\\A0*";
-  color: #dc4e41;
-}
-
-.c10 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 14px;
-  line-height: 1.428571429;
-  color: #495057;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  background-color: #fff;
-  background-image: none;
-  padding: 9px 12px;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  box-shadow: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c10:focus {
-  border-color: #5fdb94;
-  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
-  outline: 0;
-}
-
-.c10:disabled,
-.c10[readonly] {
-  background-color: #e9ecef;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #868e96;
-}
-
-.c10::-moz-placeholder {
-  color: #868e96;
-}
-
-.c10:-ms-input-placeholder {
-  color: #868e96;
-}
-
-.c10::placeholder {
-  color: #868e96;
-}
-
-.c11 {
-  margin-bottom: 10px;
-  text-align: right;
-}
-
-<div
-  className="c0"
->
-  <div>
-    <div
-      className="c1"
-    >
-      login.title
-    </div>
-    <div
-      className="r5-social-buttons c2"
-    >
-      <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
-        onClick={[Function]}
-        title="Facebook"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Facebook
-        </span>
-      </button>
-      <button
-        className="c5 r5-btn-social r5-btn-social-google"
-        onClick={[Function]}
-        title="Google"
-      >
-        <span
-          className="r5-btn-social-icon c4"
-        />
-        <span
-          className="r5-btn-social-text"
-        >
-          Google
-        </span>
-      </button>
-    </div>
-    <div
-      className="c6"
-    >
-      <span>
-        or
-      </span>
-    </div>
-    <form
-      className="c7"
-      noValidate={true}
-      onSubmit={[Function]}
-    >
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="identifier"
-        >
-          identifier
-        </label>
-        <input
-          autoComplete="username webauthn"
-          className="c10"
-          data-testid="identifier"
-          id="identifier"
-          name="identifier"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="identifier"
-          readOnly={false}
-          required={true}
-          title="identifier"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="c8"
-        required={true}
-      >
-        <label
-          className="c9"
-          htmlFor="password"
-        >
-          password
-        </label>
-        <div
-          style={
-            {
-              "position": "relative",
-            }
-          }
-        >
-          <input
-            autoComplete="current-password"
-            className="c10"
-            data-testid="password"
-            id="password"
-            name="password"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="password"
-            required={true}
-            title="password"
-            type="password"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-          href="#"
-          onClick={[Function]}
-        >
-          login.forgotPasswordLink
-        </a>
-      </div>
-      <button
-        className="c13"
-        data-testid="submit"
-        disabled={false}
-        type="submit"
-      >
-        login.submitLabel
-      </button>
-    </form>
-    <div
-      className="c14"
-    >
-      <span>
-        login.signupLinkPrefix
-      </span>
-       
-      <a
-        className="c12"
-        href="#"
-        onClick={[Function]}
-      >
-        login.signupLink
-      </a>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Snapshot with webauthn feature login old view with webauthn or password 1`] = `
-.c1 {
-  margin-bottom: 15px;
-  text-align: center;
-  color: #212529;
-  font-weight: bold;
-  font-size: 16.8px;
-}
-
-.c6 {
-  color: #adb5bd;
-  display: block;
-  text-align: center;
-  overflow: hidden;
-  white-space: nowrap;
-  margin: 10px 0;
-}
-
-.c6 > span {
-  position: relative;
-  display: inline-block;
-}
-
-.c6 > span:before,
-.c6 > span:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  width: 9999px;
-  height: 1px;
-  background: #ced4da;
-}
-
-.c6 > span:before {
-  right: 100%;
-  margin-right: 14px;
-}
-
-.c6 > span:after {
-  left: 100%;
-  margin-left: 14px;
-}
-
-.c17 {
-  text-align: center;
-  margin-top: 15px;
-  color: #495057;
-}
-
-.c18 {
-  color: #229955;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c18:hover {
-  color: #145a32;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c12 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -9497,23 +8785,23 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   transition: all .15s ease-in-out;
 }
 
-.c12:focus {
+.c8:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
 }
 
-.c12:hover,
-.c12:active {
+.c8:hover,
+.c8:active {
   color: #229955;
   background-color: #ebebeb;
   border-color: #ebebeb;
 }
 
-.c12[disabled] {
+.c8[disabled] {
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   left: 0;
   top: 0;
@@ -9525,6 +8813,205 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   background-repeat: no-repeat;
   background-size: 20px 20px;
   background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c10 {
+  width: 40px;
+  height: 40px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 .r5-button-text {
+  margin-left: 10px;
+  text-transform: uppercase;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      signup.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <div
+      className="r5-webauthn-signup-buttons "
+    >
+      <button
+        className="c8 r5-button-with-icon c9"
+        data-testid="webauthn-button"
+        disabled={false}
+        onClick={[Function]}
+        title="signup.withBiometrics"
+        type="submit"
+      >
+        <svg
+          className="c10"
+        />
+        <span
+          className="r5-button-text"
+        >
+          biometrics
+        </span>
+      </button>
+    </div>
+    <div
+      className="c11"
+    >
+      <span>
+        signup.loginLinkPrefix
+      </span>
+       
+      <a
+        className="c12"
+        href="#"
+        onClick={[Function]}
+      >
+        signup.loginLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot with webauthn feature login new view with integradted webauthn and password 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c15 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c13 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c13:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
 }
 
 .c3 {
@@ -9549,10 +9036,6 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c3:focus {
@@ -9571,7 +9054,7 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   opacity: .65;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -9593,52 +9076,108 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c14 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #229955;
+  border: 1px solid #229955;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c14:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
+}
+
+.c14:hover,
+.c14:active {
+  background-color: #1b7842;
+  border-color: #1b7842;
+}
+
+.c14[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
 }
 
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
 .c2 {
   text-align: center;
 }
 
-.c7 {
+.c8 {
   position: relative;
 }
 
-.c9 {
+.c10 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 10px;
 }
 
-.c8 > label::after {
+.c9 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c10 {
+.c11 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -9660,44 +9199,488 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   appearance: none;
 }
 
-.c10:focus {
+.c11:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c10:disabled,
-.c10[readonly] {
+.c11:disabled,
+.c11[readonly] {
   background-color: #e9ecef;
 }
 
-.c10::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c10::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #868e96;
 }
 
-.c10:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: #868e96;
 }
 
-.c14 {
-  width: 40px;
-  height: 40px;
+.c12 {
+  margin-bottom: 10px;
+  text-align: right;
 }
 
-.c16 {
-  width: 40px;
-  height: 40px;
+<div
+  className="c0"
+>
+  <div>
+    <div
+      className="c1"
+    >
+      login.title
+    </div>
+    <div
+      className="r5-social-buttons c2"
+    >
+      <button
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
+        onClick={[Function]}
+        title="Facebook"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Facebook
+        </span>
+      </button>
+      <button
+        className="c6 c4 r5-btn-social r5-btn-social-google"
+        onClick={[Function]}
+        title="Google"
+      >
+        <span
+          className="r5-btn-social-icon c5"
+        />
+        <span
+          className="r5-btn-social-text"
+        >
+          Google
+        </span>
+      </button>
+    </div>
+    <div
+      className="c7"
+    >
+      <span>
+        or
+      </span>
+    </div>
+    <form
+      className="c8"
+      noValidate={true}
+      onSubmit={[Function]}
+    >
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="identifier"
+        >
+          identifier
+        </label>
+        <input
+          autoComplete="username webauthn"
+          className="c11"
+          data-testid="identifier"
+          id="identifier"
+          name="identifier"
+          onBlur={[Function]}
+          onChange={[Function]}
+          placeholder="identifier"
+          readOnly={false}
+          required={true}
+          title="identifier"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="c9"
+        required={true}
+      >
+        <label
+          className="c10"
+          htmlFor="password"
+        >
+          password
+        </label>
+        <div
+          style={
+            {
+              "position": "relative",
+            }
+          }
+        >
+          <input
+            autoComplete="current-password"
+            className="c11"
+            data-testid="password"
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="password"
+            required={true}
+            title="password"
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="#"
+          onClick={[Function]}
+        >
+          login.forgotPasswordLink
+        </a>
+      </div>
+      <button
+        className="c14"
+        data-testid="submit"
+        disabled={false}
+        type="submit"
+      >
+        login.submitLabel
+      </button>
+    </form>
+    <div
+      className="c15"
+    >
+      <span>
+        login.signupLinkPrefix
+      </span>
+       
+      <a
+        className="c13"
+        href="#"
+        onClick={[Function]}
+      >
+        login.signupLink
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot with webauthn feature login old view with webauthn or password 1`] = `
+.c1 {
+  margin-bottom: 15px;
+  text-align: center;
+  color: #212529;
+  font-weight: bold;
+  font-size: 16.8px;
+}
+
+.c7 {
+  color: #adb5bd;
+  display: block;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.c7 > span {
+  position: relative;
+  display: inline-block;
+}
+
+.c7 > span:before,
+.c7 > span:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 9999px;
+  height: 1px;
+  background: #ced4da;
+}
+
+.c7 > span:before {
+  right: 100%;
+  margin-right: 14px;
+}
+
+.c7 > span:after {
+  left: 100%;
+  margin-left: 14px;
+}
+
+.c18 {
+  text-align: center;
+  margin-top: 15px;
+  color: #495057;
+}
+
+.c19 {
+  color: #229955;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c19:hover {
+  color: #145a32;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c3 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #3b5998;
+  border: 1px solid #3b5998;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c3:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(59,89,152,0.5);
+}
+
+.c3:hover,
+.c3:active {
+  color: #ffffff;
+  background-color: #30487b;
+  border-color: #30487b;
+}
+
+.c3[disabled] {
+  opacity: .65;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #58666e;
+  background-color: #ffffff;
+  border: 1px solid rgba(0,0,0,.15);
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
 }
 
 .c13 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #229955;
+  background-color: #ffffff;
+  border: 1px solid #ffffff;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c13:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
+}
+
+.c13:hover,
+.c13:active {
+  color: #229955;
+  background-color: #ebebeb;
+  border-color: #ebebeb;
+}
+
+.c13[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c10 {
+  color: #495057;
+  margin-bottom: 5px;
+  display: none;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c9 > label::after {
+  content: "\\A0*";
+  color: #dc4e41;
+}
+
+.c11 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #495057;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  background-color: #fff;
+  background-image: none;
+  padding: 9px 12px;
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11:focus {
+  border-color: #5fdb94;
+  box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
+  outline: 0;
+}
+
+.c11:disabled,
+.c11[readonly] {
+  background-color: #e9ecef;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #868e96;
+}
+
+.c11::-moz-placeholder {
+  color: #868e96;
+}
+
+.c11:-ms-input-placeholder {
+  color: #868e96;
+}
+
+.c11::placeholder {
+  color: #868e96;
+}
+
+.c15 {
+  width: 40px;
+  height: 40px;
+}
+
+.c17 {
+  width: 40px;
+  height: 40px;
+}
+
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9712,17 +9695,17 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   justify-content: center;
 }
 
-.c13 .r5-button-text {
+.c14 .r5-button-text {
   margin-left: 10px;
   text-transform: uppercase;
 }
 
-.c15 {
+.c16 {
   text-align: center;
   color: #adb5bd;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9733,7 +9716,7 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
   align-items: center;
 }
 
-.c11 > :not(:last-child) {
+.c12 > :not(:last-child) {
   margin-right: 20px;
 }
 
@@ -9750,12 +9733,12 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -9764,12 +9747,12 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -9779,30 +9762,30 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
       </span>
     </div>
     <form
-      className="c7"
+      className="c8"
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="c8"
+        className="c9"
         required={true}
       >
         <label
-          className="c9"
+          className="c10"
           htmlFor="identifier"
         >
           identifier
         </label>
         <input
           autoComplete="username webauthn"
-          className="c10"
+          className="c11"
           data-testid="identifier"
           id="identifier"
           name="identifier"
@@ -9817,26 +9800,26 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
         />
       </div>
       <div
-        className="r5-webauthn-login-buttons c11"
+        className="r5-webauthn-login-buttons c12"
       >
         <button
-          className="c12 r5-button-with-icon c13"
+          className="c13 r5-button-with-icon c14"
           data-testid="webauthn-button"
           disabled={false}
           title="login.withBiometrics"
           type="submit"
         >
           <svg
-            className="c14"
+            className="c15"
           />
         </button>
         <div
-          className="c15"
+          className="c16"
         >
           or
         </div>
         <button
-          className="c12 r5-button-with-icon c13"
+          className="c13 r5-button-with-icon c14"
           data-testid="password-button"
           disabled={false}
           onClick={[Function]}
@@ -9844,20 +9827,20 @@ exports[`Snapshot with webauthn feature login old view with webauthn or password
           type="submit"
         >
           <svg
-            className="c16"
+            className="c17"
           />
         </button>
       </div>
     </form>
     <div
-      className="c17"
+      className="c18"
     >
       <span>
         login.signupLinkPrefix
       </span>
        
       <a
-        className="c18"
+        className="c19"
         href="#"
         onClick={[Function]}
       >
@@ -10460,7 +10443,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   font-size: 16.8px;
 }
 
-.c6 {
+.c7 {
   color: #adb5bd;
   display: block;
   text-align: center;
@@ -10469,13 +10452,13 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   margin: 10px 0;
 }
 
-.c6 > span {
+.c7 > span {
   position: relative;
   display: inline-block;
 }
 
-.c6 > span:before,
-.c6 > span:after {
+.c7 > span:before,
+.c7 > span:after {
   content: '';
   position: absolute;
   top: 50%;
@@ -10484,29 +10467,29 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   background: #ced4da;
 }
 
-.c6 > span:before {
+.c7 > span:before {
   right: 100%;
   margin-right: 14px;
 }
 
-.c6 > span:after {
+.c7 > span:after {
   left: 100%;
   margin-left: 14px;
 }
 
-.c11 {
+.c12 {
   text-align: center;
   margin-top: 15px;
   color: #495057;
 }
 
-.c12 {
+.c13 {
   color: #229955;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12:hover {
+.c13:hover {
   color: #145a32;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10524,60 +10507,6 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   max-width: 400px;
   box-sizing: border-box;
   margin: 0 auto;
-}
-
-.c7 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  font-weight: bold;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-  color: #229955;
-  background-color: #ffffff;
-  border: 1px solid #ffffff;
-  padding: 9px 12px;
-  font-size: 14px;
-  line-height: 1.428571429;
-  border-radius: 3px;
-  -webkit-transition: all .15s ease-in-out;
-  transition: all .15s ease-in-out;
-}
-
-.c7:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
-}
-
-.c7:hover,
-.c7:active {
-  color: #229955;
-  background-color: #ebebeb;
-  border-color: #ebebeb;
-}
-
-.c7[disabled] {
-  opacity: .65;
-}
-
-.c4 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
 }
 
 .c3 {
@@ -10602,10 +10531,6 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c3:focus {
@@ -10624,7 +10549,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   opacity: .65;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -10646,35 +10571,87 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
+}
+
+.c6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0);
+}
+
+.c6:hover,
+.c6:active {
+  color: #58666e;
+  background-color: #ebebeb;
+  border-color: rgba(0,0,0,0.15);
+}
+
+.c6[disabled] {
+  opacity: .65;
+}
+
+.c8 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-weight: bold;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  color: #229955;
+  background-color: #ffffff;
+  border: 1px solid #ffffff;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.428571429;
+  border-radius: 3px;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+
+.c8:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(255,255,255,0.5);
+}
+
+.c8:hover,
+.c8:active {
+  color: #229955;
+  background-color: #ebebeb;
+  border-color: #ebebeb;
+}
+
+.c8[disabled] {
+  opacity: .65;
+}
+
+.c5 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c4 {
   margin-bottom: 10px;
   position: relative;
   width: 100%;
   height: 40px;
 }
 
-.c5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px rgba(0,0,0,0);
-}
-
-.c5:hover,
-.c5:active {
-  color: #58666e;
-  background-color: #ebebeb;
-  border-color: rgba(0,0,0,0.15);
-}
-
-.c5[disabled] {
-  opacity: .65;
-}
-
 .c2 {
   text-align: center;
-}
-
-.c9 {
-  width: 40px;
-  height: 40px;
 }
 
 .c10 {
@@ -10682,7 +10659,12 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   height: 40px;
 }
 
-.c8 {
+.c11 {
+  width: 40px;
+  height: 40px;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10697,7 +10679,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
   justify-content: center;
 }
 
-.c8 .r5-button-text {
+.c9 .r5-button-text {
   margin-left: 10px;
   text-transform: uppercase;
 }
@@ -10715,12 +10697,12 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
       className="r5-social-buttons c2"
     >
       <button
-        className="c3 r5-btn-social r5-btn-social-facebook"
+        className="c3 c4 r5-btn-social r5-btn-social-facebook"
         onClick={[Function]}
         title="Facebook"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -10729,12 +10711,12 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
         </span>
       </button>
       <button
-        className="c5 r5-btn-social r5-btn-social-google"
+        className="c6 c4 r5-btn-social r5-btn-social-google"
         onClick={[Function]}
         title="Google"
       >
         <span
-          className="r5-btn-social-icon c4"
+          className="r5-btn-social-icon c5"
         />
         <span
           className="r5-btn-social-text"
@@ -10744,7 +10726,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
       </button>
     </div>
     <div
-      className="c6"
+      className="c7"
     >
       <span>
         or
@@ -10754,7 +10736,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
       className="r5-webauthn-signup-buttons "
     >
       <button
-        className="c7 r5-button-with-icon c8"
+        className="c8 r5-button-with-icon c9"
         data-testid="webauthn-button"
         disabled={false}
         onClick={[Function]}
@@ -10762,7 +10744,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
         type="submit"
       >
         <svg
-          className="c9"
+          className="c10"
         />
         <span
           className="r5-button-text"
@@ -10771,14 +10753,14 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
         </span>
       </button>
       <div
-        className="c6"
+        className="c7"
       >
         <span>
           or
         </span>
       </div>
       <button
-        className="c7 r5-button-with-icon c8"
+        className="c8 r5-button-with-icon c9"
         data-testid="password-button"
         disabled={false}
         onClick={[Function]}
@@ -10786,7 +10768,7 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
         type="submit"
       >
         <svg
-          className="c10"
+          className="c11"
         />
         <span
           className="r5-button-text"
@@ -10796,14 +10778,14 @@ exports[`Snapshot with webauthn feature signup view with webauthn or password 1`
       </button>
     </div>
     <div
-      className="c11"
+      className="c12"
     >
       <span>
         signup.loginLinkPrefix
       </span>
        
       <a
-        className="c12"
+        className="c13"
         href="#"
         onClick={[Function]}
       >

--- a/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
+++ b/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.js.snap
@@ -3,24 +3,24 @@
 exports[`Snapshot mfaCredentials default 1`] = `
 <div>
   <div
-    class="sc-AxmLO cCElfg"
+    class="sc-imWYAI fLZoZn"
   >
     <div>
       <div
-        class="sc-fzoXzr jzxwMq"
+        class="sc-gFqAkR cwAydj"
       >
         <div>
           <div
-            class="sc-AxirZ sc-AxiKw fAiBCP"
+            class="sc-gEvEer sc-eqUAAy bEpsus iRHKeq"
           >
             mfa.email.explain
           </div>
           <form
-            class="sc-fzoyAV eLHLnL"
+            class="sc-eldPxv kupyLT"
             novalidate=""
           >
             <button
-              class="sc-fzqNJr gWXXZS"
+              class="sc-eDPEul gVbigW"
               data-testid="submit"
               type="submit"
             >
@@ -29,7 +29,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
           </form>
         </div>
         <div
-          class="sc-AxgMl fOrrlo"
+          class="sc-iGgWBj fIbmkT"
         >
           <span>
             or
@@ -37,27 +37,27 @@ exports[`Snapshot mfaCredentials default 1`] = `
         </div>
         <div>
           <div
-            class="sc-AxirZ sc-AxiKw fAiBCP"
+            class="sc-gEvEer sc-eqUAAy bEpsus iRHKeq"
           >
             mfa.phoneNumber.explain
           </div>
           <form
-            class="sc-fzoyAV eLHLnL"
+            class="sc-eldPxv kupyLT"
             novalidate=""
           >
             <div
-              class="sc-fzplWN japiTA"
+              class="sc-dAlyuH gNVVUe"
               required=""
             >
               <label
-                class="sc-fzoLsD ggcsuZ"
+                class="sc-dhKdcB mUniF"
                 for="phone_number"
               >
                 phoneNumber
               </label>
               <input
                 autocomplete="tel"
-                class="sc-fznyAO liPuGS"
+                class="sc-jlZhew gZoAQH"
                 data-testid="phone_number"
                 id="phone_number"
                 labels="[object Object]"
@@ -69,7 +69,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
               />
             </div>
             <button
-              class="sc-fzqNJr gWXXZS"
+              class="sc-eDPEul gVbigW"
               data-testid="submit"
               type="submit"
             >
@@ -79,7 +79,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
         </div>
       </div>
       <div
-        class="sc-fzoXzr jzxwMq"
+        class="sc-gFqAkR cwAydj"
       />
     </div>
   </div>
@@ -89,22 +89,22 @@ exports[`Snapshot mfaCredentials default 1`] = `
 exports[`Snapshot mfaCredentials no intro 1`] = `
 <div>
   <div
-    class="sc-AxmLO cCElfg"
+    class="sc-imWYAI fLZoZn"
   >
     <div>
       <div
-        class="sc-fzoXzr jzxwMq"
+        class="sc-gFqAkR cwAydj"
       />
       <div
-        class="sc-fzoXzr jzxwMq"
+        class="sc-gFqAkR cwAydj"
       >
         <div>
           <form
-            class="sc-fzoyAV eLHLnL"
+            class="sc-eldPxv kupyLT"
             novalidate=""
           >
             <button
-              class="sc-fzqNJr gWXXZS"
+              class="sc-eDPEul gVbigW"
               data-testid="submit"
               type="submit"
             >
@@ -113,7 +113,7 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
           </form>
         </div>
         <div
-          class="sc-AxgMl fOrrlo"
+          class="sc-iGgWBj fIbmkT"
         >
           <span>
             or
@@ -121,11 +121,11 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
         </div>
         <div>
           <form
-            class="sc-fzoyAV eLHLnL"
+            class="sc-eldPxv kupyLT"
             novalidate=""
           >
             <button
-              class="sc-fzqNJr gWXXZS"
+              class="sc-eDPEul gVbigW"
               data-testid="submit"
               type="submit"
             >

--- a/tests/widgets/mfa/__snapshots__/mfaListWidget.test.js.snap
+++ b/tests/widgets/mfa/__snapshots__/mfaListWidget.test.js.snap
@@ -1,38 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Snapshot basic 1`] = `
-.c0 {
-  font-size: 14px;
-  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
-  -webkit-transition: transform 400ms ease, opacity 400ms ease;
-  transition: transform 400ms ease, opacity 400ms ease;
-  opacity: 0;
-  padding: 20px;
-  border-radius: 3px;
-  background-color: #ffffff;
-  max-width: 400px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
-.c4 {
-  width: 28px;
-  height: 28px;
-  fill: #495057;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.c2 {
-  width: 28px;
-  height: 28px;
-  fill: #495057;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
 .c1 {
   padding: 9px 38px;
   border: 1px solid #ced4da;
@@ -41,19 +9,6 @@ exports[`Snapshot basic 1`] = `
   white-space: nowrap;
   vertical-align: middle;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #495057;
-  line-height: 1.5;
 }
 
 .c1:only-child {
@@ -72,7 +27,55 @@ exports[`Snapshot basic 1`] = `
   border-bottom-width: 0;
 }
 
+.c0 {
+  font-size: 14px;
+  -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
+  -webkit-transition: transform 400ms ease, opacity 400ms ease;
+  transition: transform 400ms ease, opacity 400ms ease;
+  opacity: 0;
+  padding: 20px;
+  border-radius: 3px;
+  background-color: #ffffff;
+  max-width: 400px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.c5 {
+  width: 28px;
+  height: 28px;
+  fill: #495057;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
 .c3 {
+  width: 28px;
+  height: 28px;
+  fill: #495057;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #495057;
+  line-height: 1.5;
+}
+
+.c4 {
   margin-left: 38px;
   white-space: initial;
 }
@@ -82,13 +85,13 @@ exports[`Snapshot basic 1`] = `
 >
   <div>
     <div
-      className="c1"
+      className="c1 c2"
     >
       <svg
-        className="c2"
+        className="c3"
       />
       <div
-        className="c3"
+        className="c4"
       >
         <div
           style={
@@ -116,13 +119,13 @@ exports[`Snapshot basic 1`] = `
       </div>
     </div>
     <div
-      className="c1"
+      className="c1 c2"
     >
       <svg
-        className="c4"
+        className="c5"
       />
       <div
-        className="c3"
+        className="c4"
       >
         <div
           style={
@@ -157,6 +160,9 @@ exports[`Snapshot empty 1`] = `
 .c1 {
   text-align: center;
   margin-bottom: 10px;
+}
+
+.c2 {
   color: #495057;
 }
 
@@ -179,7 +185,7 @@ exports[`Snapshot empty 1`] = `
 >
   <div>
     <div
-      className="c1"
+      className="c1 c2"
     >
       mfaList.noCredentials
     </div>

--- a/tests/widgets/passwordReset/__snapshots__/passwordResetWidget.test.ts.snap
+++ b/tests/widgets/passwordReset/__snapshots__/passwordResetWidget.test.ts.snap
@@ -12,6 +12,9 @@ exports[`Snapshot password-reset default 1`] = `
 .c2 {
   text-align: center;
   margin-bottom: 10px;
+}
+
+.c3 {
   color: #495057;
 }
 
@@ -29,7 +32,7 @@ exports[`Snapshot password-reset default 1`] = `
   margin: 0 auto;
 }
 
-.c7 {
+.c8 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -53,41 +56,41 @@ exports[`Snapshot password-reset default 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c7:focus {
+.c8:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c7:hover,
-.c7:active {
+.c8:hover,
+.c8:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c7[disabled] {
+.c8[disabled] {
   opacity: .65;
 }
 
-.c3 {
+.c4 {
   position: relative;
 }
 
-.c5 {
+.c6 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c4 {
+.c5 {
   margin-bottom: 10px;
 }
 
-.c4 > label::after {
+.c5 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c6 {
+.c7 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -109,30 +112,30 @@ exports[`Snapshot password-reset default 1`] = `
   appearance: none;
 }
 
-.c6:focus {
+.c7:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c6:disabled,
-.c6[readonly] {
+.c7:disabled,
+.c7[readonly] {
   background-color: #e9ecef;
 }
 
-.c6::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c6::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #868e96;
 }
 
-.c6:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c6::placeholder {
+.c7::placeholder {
   color: #868e96;
 }
 
@@ -147,20 +150,20 @@ exports[`Snapshot password-reset default 1`] = `
         passwordReset.title
       </div>
       <div
-        class="c2"
+        class="c2 c3"
       >
         passwordReset.intro
       </div>
       <form
-        class="c3"
+        class="c4"
         novalidate=""
       >
         <div
-          class="c4"
+          class="c5"
           required=""
         >
           <label
-            class="c5"
+            class="c6"
             for="password"
           >
             newPassword
@@ -170,7 +173,7 @@ exports[`Snapshot password-reset default 1`] = `
           >
             <input
               autocomplete="new-password"
-              class="c6"
+              class="c7"
               data-testid="password"
               id="password"
               name="password"
@@ -183,11 +186,11 @@ exports[`Snapshot password-reset default 1`] = `
           </div>
         </div>
         <div
-          class="c4"
+          class="c5"
           required=""
         >
           <label
-            class="c5"
+            class="c6"
             for="password_confirmation"
           >
             passwordConfirmation
@@ -197,7 +200,7 @@ exports[`Snapshot password-reset default 1`] = `
           >
             <input
               autocomplete="new-password"
-              class="c6"
+              class="c7"
               data-testid="password_confirmation"
               id="password_confirmation"
               name="password_confirmation"
@@ -210,7 +213,7 @@ exports[`Snapshot password-reset default 1`] = `
           </div>
         </div>
         <button
-          class="c7"
+          class="c8"
           data-testid="submit"
           type="submit"
         >

--- a/tests/widgets/passwordless/__snapshots__/passwordlessWidget.test.js.snap
+++ b/tests/widgets/passwordless/__snapshots__/passwordlessWidget.test.js.snap
@@ -4,6 +4,9 @@ exports[`Snapshot passwordless default 1`] = `
 .c1 {
   text-align: center;
   margin-bottom: 10px;
+}
+
+.c2 {
   color: #495057;
 }
 
@@ -21,7 +24,7 @@ exports[`Snapshot passwordless default 1`] = `
   margin: 0 auto;
 }
 
-.c6 {
+.c7 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -45,41 +48,41 @@ exports[`Snapshot passwordless default 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c6:hover,
-.c6:active {
+.c7:hover,
+.c7:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c6[disabled] {
+.c7[disabled] {
   opacity: .65;
 }
 
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c4 {
+.c5 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c3 {
+.c4 {
   margin-bottom: 10px;
 }
 
-.c3 > label::after {
+.c4 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -101,30 +104,30 @@ exports[`Snapshot passwordless default 1`] = `
   appearance: none;
 }
 
-.c5:focus {
+.c6:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c5:disabled,
-.c5[readonly] {
+.c6:disabled,
+.c6[readonly] {
   background-color: #e9ecef;
 }
 
-.c5::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c5::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #868e96;
 }
 
-.c5:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c5::placeholder {
+.c6::placeholder {
   color: #868e96;
 }
 
@@ -134,26 +137,26 @@ exports[`Snapshot passwordless default 1`] = `
   >
     <div>
       <div
-        class="c1"
+        class="c1 c2"
       >
         passwordless.intro
       </div>
       <form
-        class="c2"
+        class="c3"
         novalidate=""
       >
         <div
-          class="c3"
+          class="c4"
           required=""
         >
           <label
-            class="c4"
+            class="c5"
             for="email"
           >
             email
           </label>
           <input
-            class="c5"
+            class="c6"
             data-testid="email"
             id="email"
             name="email"
@@ -165,7 +168,7 @@ exports[`Snapshot passwordless default 1`] = `
           />
         </div>
         <button
-          class="c6"
+          class="c7"
           data-testid="submit"
           type="submit"
         >
@@ -347,6 +350,9 @@ exports[`Snapshot passwordless sms 1`] = `
 .c1 {
   text-align: center;
   margin-bottom: 10px;
+}
+
+.c2 {
   color: #495057;
 }
 
@@ -364,7 +370,7 @@ exports[`Snapshot passwordless sms 1`] = `
   margin: 0 auto;
 }
 
-.c6 {
+.c7 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -388,41 +394,41 @@ exports[`Snapshot passwordless sms 1`] = `
   transition: all .15s ease-in-out;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(34,153,85,0.5);
 }
 
-.c6:hover,
-.c6:active {
+.c7:hover,
+.c7:active {
   background-color: #1b7842;
   border-color: #1b7842;
 }
 
-.c6[disabled] {
+.c7[disabled] {
   opacity: .65;
 }
 
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c4 {
+.c5 {
   color: #495057;
   margin-bottom: 5px;
   display: none;
 }
 
-.c3 {
+.c4 {
   margin-bottom: 10px;
 }
 
-.c3 > label::after {
+.c4 > label::after {
   content: "\\A0*";
   color: #dc4e41;
 }
 
-.c5 {
+.c6 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -444,30 +450,30 @@ exports[`Snapshot passwordless sms 1`] = `
   appearance: none;
 }
 
-.c5:focus {
+.c6:focus {
   border-color: #5fdb94;
   box-shadow: 0 0 0 3px rgba(95,219,148,0.5);
   outline: 0;
 }
 
-.c5:disabled,
-.c5[readonly] {
+.c6:disabled,
+.c6[readonly] {
   background-color: #e9ecef;
 }
 
-.c5::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #868e96;
 }
 
-.c5::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #868e96;
 }
 
-.c5:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #868e96;
 }
 
-.c5::placeholder {
+.c6::placeholder {
   color: #868e96;
 }
 
@@ -477,27 +483,27 @@ exports[`Snapshot passwordless sms 1`] = `
   >
     <div>
       <div
-        class="c1"
+        class="c1 c2"
       >
         passwordless.sms.intro
       </div>
       <form
-        class="c2"
+        class="c3"
         novalidate=""
       >
         <div
-          class="c3"
+          class="c4"
           required=""
         >
           <label
-            class="c4"
+            class="c5"
             for="phone_number"
           >
             phoneNumber
           </label>
           <input
             autocomplete="tel"
-            class="c5"
+            class="c6"
             data-testid="phone_number"
             id="phone_number"
             name="phone_number"
@@ -508,7 +514,7 @@ exports[`Snapshot passwordless sms 1`] = `
           />
         </div>
         <button
-          class="c6"
+          class="c7"
           data-testid="submit"
           type="submit"
         >

--- a/tests/widgets/profileEditor/__snapshots__/profileEditorWidget.test.js.snap
+++ b/tests/widgets/profileEditor/__snapshots__/profileEditorWidget.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Snapshot profile editor basic 1`] = `
+.c6 {
+  color: #adb5bd;
+}
+
 .c0 {
   font-size: 14px;
   -webkit-transition: -webkit-transform 400ms ease, opacity 400ms ease;
@@ -58,8 +62,7 @@ exports[`Snapshot profile editor basic 1`] = `
   position: relative;
 }
 
-.c6 {
-  color: #adb5bd;
+.c7 {
   display: block;
   padding: 9px 12px;
   text-align: center;
@@ -187,7 +190,7 @@ exports[`Snapshot profile editor basic 1`] = `
         save
       </button>
       <span
-        class="c6"
+        class="c6 c7"
       >
         *
         form.required.fields

--- a/tests/widgets/socialLogin/__snapshots__/socialLogin.test.ts.snap
+++ b/tests/widgets/socialLogin/__snapshots__/socialLogin.test.ts.snap
@@ -9,20 +9,6 @@ exports[`Snapshot social login basic 1`] = `
   opacity: 0;
 }
 
-.c3 {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 38px;
-  box-sizing: border-box;
-  border-radius: 2px;
-  background-image: url(svg);
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-  background-position: center center;
-}
-
 .c2 {
   display: block;
   width: 100%;
@@ -45,10 +31,6 @@ exports[`Snapshot social login basic 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
 .c2:focus {
@@ -67,7 +49,7 @@ exports[`Snapshot social login basic 1`] = `
   opacity: .65;
 }
 
-.c4 {
+.c5 {
   display: block;
   width: 100%;
   box-sizing: border-box;
@@ -89,26 +71,43 @@ exports[`Snapshot social login basic 1`] = `
   border-radius: 3px;
   -webkit-transition: all .15s ease-in-out;
   transition: all .15s ease-in-out;
-  margin-bottom: 10px;
-  position: relative;
-  width: 100%;
-  height: 40px;
 }
 
-.c4:focus {
+.c5:focus {
   outline: 0;
   box-shadow: 0 0 0 3px rgba(0,0,0,0);
 }
 
-.c4:hover,
-.c4:active {
+.c5:hover,
+.c5:active {
   color: #58666e;
   background-color: #ebebeb;
   border-color: rgba(0,0,0,0.15);
 }
 
-.c4[disabled] {
+.c5[disabled] {
   opacity: .65;
+}
+
+.c4 {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 38px;
+  box-sizing: border-box;
+  border-radius: 2px;
+  background-image: url(svg);
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  background-position: center center;
+}
+
+.c3 {
+  margin-bottom: 10px;
+  position: relative;
+  width: 100%;
+  height: 40px;
 }
 
 .c1 {
@@ -122,12 +121,12 @@ exports[`Snapshot social login basic 1`] = `
     className="r5-social-buttons c1"
   >
     <button
-      className="c2 r5-btn-social r5-btn-social-facebook"
+      className="c2 c3 r5-btn-social r5-btn-social-facebook"
       onClick={[Function]}
       title="Facebook"
     >
       <span
-        className="r5-btn-social-icon c3"
+        className="r5-btn-social-icon c4"
       />
       <span
         className="r5-btn-social-text"
@@ -136,12 +135,12 @@ exports[`Snapshot social login basic 1`] = `
       </span>
     </button>
     <button
-      className="c4 r5-btn-social r5-btn-social-google"
+      className="c5 c3 r5-btn-social r5-btn-social-google"
       onClick={[Function]}
       title="Google"
     >
       <span
-        className="r5-btn-social-icon c3"
+        className="r5-btn-social-icon c4"
       />
       <span
         className="r5-btn-social-text"

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
  * @reachfive/identity-ui - v1.32.0
- * Compiled Wed, 05 Feb 2025 14:52:54 UTC
+ * Compiled Wed, 05 Feb 2025 20:22:21 UTC
  *
  * Copyright (c) ReachFive.
  *


### PR DESCRIPTION
During the release au React v18 upgrade, there is an issue with update of `styled-components` and his method `createGlobalStyle` used to inject global styles.
In ou use case it is used to inject <PhoneNumberInput/> component styles.
With the option `withCountrySelect` enabled to display the country flags selector, the flag was not styled.

I managed to fix this issue. It was due to a rollup option to defined the browser context.