### PR TITLE
[CA-4747] Profile editor should update consents with key in snakecase

### DIFF
--- a/src/components/form/fields/consentField.tsx
+++ b/src/components/form/fields/consentField.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 
 import styled from 'styled-components';
 
+import { ConsentType } from '@reachfive/identity-core';
+
 import { Checkbox } from '../formControlsComponent';
 import { createField, type FieldComponentProps, type FieldDefinition } from '../fieldCreator';
 import { MarkdownContent } from '../../miscComponent';
 
+import { PathMapping } from '../../../core/mapping';
 import { checked, empty, isValidatorError } from '../../../core/validation';
 import { isRichFormValue } from '../../../helpers/utils';
-import { ConsentType } from '@reachfive/identity-core';
+import { snakeCasePath } from '../../../helpers/transformObjectProperties';
 
 const Description = styled.div`
     font-size: ${props => props.theme.smallTextFontSize}px;
@@ -80,6 +83,7 @@ export default function consentField({
         ...props,
         required,
         defaultValue: { granted: props.defaultValue ?? false },
+        mapping: new PathMapping(snakeCasePath(props.path ?? props.key)), // Consent key should be snake_case
         format: {
             bind: value => value,
             unbind: value => value !== undefined

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,14 +34,19 @@ export function createClient(creationConfig: Config): Client {
 
         return fetch(`https://${creationConfig.domain}/identity/v1/config/consents?${toQueryString({ lang: language })}`)
             .then(response => response.json())
-            .then(consentsVersions => {
+            .then((consentsVersions: Record<string, ConsentVersions>) => {
                 return fetch(`${remoteConfig.resourceBaseUrl}/${language}.json`)
                     .then(response => response.json())
                     .then(defaultI18n => {
                         const config = {
                             ...creationConfig,
                             ...remoteConfig,
-                            consentsVersions: camelCaseProperties(consentsVersions) as Record<string, ConsentVersions>
+                            consentsVersions: Object.fromEntries(
+                                Object.entries(consentsVersions).map(([key, value]) => [
+                                    key, // consents keys should be snake_case
+                                    camelCaseProperties(value) as ConsentVersions
+                                ])
+                            )
                         }
                         return new UiClient(config, coreClient, defaultI18n)
                     })

--- a/src/widgets/profileEditor/profileEditorWidget.tsx
+++ b/src/widgets/profileEditor/profileEditorWidget.tsx
@@ -77,7 +77,7 @@ const ProfileEditor = ({
             accessToken: accessToken,
             redirectUrl: redirectUrl
         });
-    console.log('ProfileEditor', profile)
+
     return (
         <ProfileEditorForm
             handler={handleSubmit}


### PR DESCRIPTION
[CA-4747](https://reach5.atlassian.net/browse/CA-4747)

L'idéal serait que la clé d'un consentement soit en valeur d'une propriété "key" et non une clé de la structure Map utilisée.
Le mieux serait même que `consents` soit un array et non un map.
Mais bon, difficile de changer ça maintenant sans créer un breaking change pour les utilisateurs de l'api ou du sdk core...

[CA-4747]: https://reach5.atlassian.net/browse/CA-4747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ