### PR TITLE
Release v1.34.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,9 @@ insert_final_newline = true
 
 [*.yml]
 indent_size = 2
+
+[tailwind.config.cjs]
+indent_size = 2
+
+[src/components/ui/*]
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.33.3] - 2025-05-13
+
+### Fixed
+
+- Embed TailwindCSS utils in bundle
+- Wrap dialog with theme provider (react portal)
+
 ## [1.33.2] - 2025-04-10
 
 ### Fixed
@@ -597,7 +604,9 @@ The eye icon is now correctly displayed in the Auth widget.
 
 First version of the SDK Web UI.
 
-[Unreleased]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.2...HEAD
+[Unreleased]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.3...HEAD
+
+[1.33.3]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.2...v1.33.3
 
 [1.33.2]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.1...v1.33.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.33.3] - 2025-05-13
+## [1.34.0] - 2025-05-13
+
+### Added
+- Allow to trust device during mfa credential registration
 
 ### Fixed
 
@@ -604,9 +607,9 @@ The eye icon is now correctly displayed in the Auth widget.
 
 First version of the SDK Web UI.
 
-[Unreleased]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.3...HEAD
+[Unreleased]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.34.0...HEAD
 
-[1.33.3]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.2...v1.33.3
+[1.34.0]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.2...v1.34.0
 
 [1.33.2]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.1...v1.33.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.33.2",
+    "version": "1.33.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@reachfive/identity-ui",
-            "version": "1.33.2",
+            "version": "1.33.3",
             "license": "MIT",
             "dependencies": {
                 "@reachfive/identity-core": "^1.35.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "@babel/preset-typescript": "^7.23.2",
                 "@eslint/js": "^9.16.0",
                 "@jest/globals": "^29.7.0",
+                "@rollup/plugin-alias": "^5.1.1",
                 "@rollup/plugin-commonjs": "^25.0.7",
                 "@rollup/plugin-dynamic-import-vars": "^2.1.2",
                 "@rollup/plugin-node-resolve": "^15.2.3",
@@ -4844,6 +4845,24 @@
             "dependencies": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
+            }
+        },
+        "node_modules/@rollup/plugin-alias": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
+            "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@rollup/plugin-commonjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.33.3",
+    "version": "1.34.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@reachfive/identity-ui",
-            "version": "1.33.3",
+            "version": "1.34.0",
             "license": "MIT",
             "dependencies": {
-                "@reachfive/identity-core": "^1.35.1",
+                "@reachfive/identity-core": "^1.36.0",
                 "buffer": "^6.0.3",
                 "char-info": "0.3.2",
                 "class-variance-authority": "^0.7.1",
@@ -4829,9 +4829,9 @@
             "license": "MIT"
         },
         "node_modules/@reachfive/identity-core": {
-            "version": "1.35.1",
-            "resolved": "https://registry.npmjs.org/@reachfive/identity-core/-/identity-core-1.35.1.tgz",
-            "integrity": "sha512-EYClN8oWNJK95XYAX1ExjfuyjyY8I4fdAp1yIPknZjtnAdXmZ4CcFZ9bsdGJJkRZFesJxufw2yGGHiSPfn1P/A==",
+            "version": "1.36.0",
+            "resolved": "https://registry.npmjs.org/@reachfive/identity-core/-/identity-core-1.36.0.tgz",
+            "integrity": "sha512-pnXBmPITmHqKU6q8zarVi5qFLkae3yVxSlCVnuairW+YVPVX4JgZfghCk0zaJkL+xg4KjW5a9s8Su2sxUqLqZg==",
             "license": "MIT",
             "dependencies": {
                 "buffer": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.33.2",
+    "version": "1.33.3",
     "description": "ReachFive Identity Web UI SDK",
     "author": "ReachFive",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.33.3",
+    "version": "1.34.0",
     "description": "ReachFive Identity Web UI SDK",
     "author": "ReachFive",
     "repository": {
@@ -31,7 +31,7 @@
         "lint": "eslint -c eslint.config.mjs src/"
     },
     "dependencies": {
-        "@reachfive/identity-core": "^1.35.1",
+        "@reachfive/identity-core": "^1.36.0",
         "buffer": "^6.0.3",
         "char-info": "0.3.2",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@babel/preset-typescript": "^7.23.2",
         "@eslint/js": "^9.16.0",
         "@jest/globals": "^29.7.0",
+        "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-dynamic-import-vars": "^2.1.2",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,16 +1,17 @@
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
-
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "./button"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { type AlertDialogActionProps } from "@radix-ui/react-alert-dialog";
 import { type VariantProps } from "class-variance-authority";
-import { AlertDialogActionProps } from "@radix-ui/react-alert-dialog";
+import * as React from "react";
 
-const AlertDialog = AlertDialogPrimitive.Root
+import { cn } from "@/lib/utils";
+import { ThemeVariablesContainer } from "../widget/widget";
+import { buttonVariants } from "./button";
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -24,26 +25,30 @@ const AlertDialogOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 drop-shadow-md duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    />
-  </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+>(({ className, ...props }, ref) => {
+  return (
+    <AlertDialogPortal>
+      <ThemeVariablesContainer className="r5-widget">
+        <AlertDialogOverlay />
+        <AlertDialogPrimitive.Content
+          ref={ref}
+          className={cn(
+            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 drop-shadow-md duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+            className
+          )}
+          {...props}
+        />
+      </ThemeVariablesContainer>
+    </AlertDialogPortal>
+  );
+});
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -56,8 +61,8 @@ const AlertDialogHeader = ({
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({
   className,
@@ -70,8 +75,8 @@ const AlertDialogFooter = ({
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -82,8 +87,8 @@ const AlertDialogTitle = React.forwardRef<
     className={cn("text-lg font-semibold", className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -94,12 +99,12 @@ const AlertDialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 export interface ActionProps
-extends AlertDialogActionProps,
+  extends AlertDialogActionProps,
     VariantProps<typeof buttonVariants> {}
 
 const AlertDialogAction = React.forwardRef<
@@ -111,8 +116,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants({ variant }), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -120,26 +125,22 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={cn(
-      buttonVariants({ variant: "outline" }),
-      "sm:mt-0",
-      className
-    )}
+    className={cn(buttonVariants({ variant: "outline" }), "sm:mt-0", className)}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/components/widget/widget.tsx
+++ b/src/components/widget/widget.tsx
@@ -1,136 +1,187 @@
-import React, { ComponentType } from 'react';
-import styled, {StyleSheetManager, ThemeProvider} from 'styled-components'
-import type { SessionInfo, Client as CoreClient } from '@reachfive/identity-core'
+import type {
+    Client as CoreClient,
+    SessionInfo,
+} from "@reachfive/identity-core";
+import React, { ComponentType } from "react";
+import styled, {
+    css,
+    StyleSheetManager,
+    ThemeProvider,
+} from "styled-components";
 
-import type { Config, Prettify } from '../../types'
-import type { I18nMessages, I18nNestedMessages } from '../../core/i18n';
+import type { I18nMessages, I18nNestedMessages } from "../../core/i18n";
+import type { Config, Prettify } from "../../types";
 
-import { ConfigProvider } from '../../contexts/config';
-import { I18nProvider } from '../../contexts/i18n'
-import { ReachfiveProvider } from '../../contexts/reachfive'
-import { RoutingProvider } from '../../contexts/routing'
-import { SessionProvider } from '../../contexts/session'
+import { ConfigProvider } from "../../contexts/config";
+import { I18nProvider } from "../../contexts/i18n";
+import { ReachfiveProvider } from "../../contexts/reachfive";
+import { RoutingProvider } from "../../contexts/routing";
+import { SessionProvider } from "../../contexts/session";
 
-import { Theme, ThemeOptions } from '../../types/styled'
-import { buildTheme } from '../../core/theme'
+import { buildTheme } from "../../core/theme";
+import { Theme, ThemeOptions } from "../../types/styled";
 
-import WidgetContainer, { WidgetContainerProps } from './widgetContainerComponent';
+import WidgetContainer, {
+    WidgetContainerProps,
+} from "./widgetContainerComponent";
 
-export type I18nProps = { i18n?: I18nNestedMessages }
-export type ThemeProps = { theme?: ThemeOptions }
+export type I18nProps = { i18n?: I18nNestedMessages };
+export type ThemeProps = { theme?: ThemeOptions };
 
-export type PropsWithI18n<P> = Prettify<P & I18nProps>
-export type PropsWithTheme<P> = Prettify<P & ThemeProps>
+export type PropsWithI18n<P> = Prettify<P & I18nProps>;
+export type PropsWithTheme<P> = Prettify<P & ThemeProps>;
 
-const WidgetContainerThemeVariables = styled(WidgetContainer)`
-    --color-primary: ${props => props.theme.primaryColor};
-    --color-destructive: ${props => props.theme.dangerColor};
-    --color-background: ${props => props.theme.backgroundColor};
-    --color-text: ${props => props.theme.textColor};
-    --color-border: ${props => props.theme.borderColor};
+export const themeVariables = css`
+    --color-primary: ${(props) => props.theme.primaryColor};
+    --color-destructive: ${(props) => props.theme.dangerColor};
+    --color-background: ${(props) => props.theme.backgroundColor};
+    --color-text: ${(props) => props.theme.textColor};
+    --color-border: ${(props) => props.theme.borderColor};
 
-    --spacing-padding-y: ${props => props.theme.paddingY};
-    --spacing-padding-x: ${props => props.theme.paddingX};
-    --spacing-block-inner-height: ${props => props.theme._blockInnerHeight};
-    --spacing: ${props => props.theme.spacing};
+    --spacing-padding-y: ${(props) => props.theme.paddingY};
+    --spacing-padding-x: ${(props) => props.theme.paddingX};
+    --spacing-block-inner-height: ${(props) => props.theme._blockInnerHeight};
+    --spacing: ${(props) => props.theme.spacing};
 
-    --font-generic: ${props => props.theme.fontSize};
+    --font-generic: ${(props) => props.theme.fontSize};
 
-    --border-width: ${props => props.theme.borderWidth};
-    --radius: ${props => props.theme.borderRadius};
-`
+    --border-width: ${(props) => props.theme.borderWidth};
+    --radius: ${(props) => props.theme.borderRadius};
+`;
+
+export const ThemeVariablesContainer = styled.div`
+    ${themeVariables}
+`;
+
+export const WidgetContainerThemeVariables = styled(WidgetContainer)`
+    ${themeVariables}
+`;
 
 export type Context = {
-    config: Config
-    apiClient: CoreClient
-    defaultI18n: I18nMessages
-    session?: SessionInfo
-}
+    config: Config;
+    apiClient: CoreClient;
+    defaultI18n: I18nMessages;
+    session?: SessionInfo;
+};
 
-type PrepareFn<P, U> = (options: PropsWithI18n<PropsWithTheme<P>>, context: Context) => PropsWithI18n<PropsWithTheme<U>> | PromiseLike<PropsWithI18n<PropsWithTheme<U>>>
+type PrepareFn<P, U> = (
+    options: PropsWithI18n<PropsWithTheme<P>>,
+    context: Context
+) =>
+    | PropsWithI18n<PropsWithTheme<U>>
+    | PromiseLike<PropsWithI18n<PropsWithTheme<U>>>;
 
 type CreateWidget<P, U> = {
-    component: ComponentType<Omit<U, 'theme'>>
-    prepare?: PrepareFn<P, U>
-} & WidgetContainerProps
-
+    component: ComponentType<Omit<U, "theme">>;
+    prepare?: PrepareFn<P, U>;
+} & WidgetContainerProps;
 
 export function createWidget<P, U = P>({
     component,
-    prepare = (options: PropsWithI18n<PropsWithTheme<P>>) => options as unknown as PropsWithI18n<PropsWithTheme<U>>,
+    prepare = (options: PropsWithI18n<PropsWithTheme<P>>) =>
+        options as unknown as PropsWithI18n<PropsWithTheme<U>>,
     ...widgetAttrs
 }: CreateWidget<P, U>) {
     return (options: PropsWithTheme<PropsWithI18n<P>>, context: Context) => {
-        return Promise.resolve(prepare(options, context)).then(({ theme: customTheme, ...preparedOptions }) => {
-            const Component = component
+        return Promise.resolve(prepare(options, context)).then(
+            ({ theme: customTheme, ...preparedOptions }) => {
+                const Component = component;
 
-            const theme: Theme = buildTheme(customTheme)
+                const theme: Theme = buildTheme(customTheme);
 
-            return (
-                <ConfigProvider config={context.config}>
-                    <ReachfiveProvider client={context.apiClient}>
-                        <SessionProvider session={context.session}>
-                            <StyleSheetManager>
-                                <ThemeProvider theme={theme}>
-                                    <I18nProvider defaultMessages={context.defaultI18n} messages={preparedOptions.i18n}>
-                                        <WidgetContainerThemeVariables {...widgetAttrs} className="r5-widget">
-                                            <Component {...preparedOptions} />
-                                        </WidgetContainerThemeVariables>
-                                    </I18nProvider>
-                                </ThemeProvider>
-                            </StyleSheetManager>
-                        </SessionProvider>
-                    </ReachfiveProvider>
-                </ConfigProvider>
-            );
-        });
-    }
+                return (
+                    <ConfigProvider config={context.config}>
+                        <ReachfiveProvider client={context.apiClient}>
+                            <SessionProvider session={context.session}>
+                                <StyleSheetManager>
+                                    <ThemeProvider theme={theme}>
+                                        <I18nProvider
+                                            defaultMessages={
+                                                context.defaultI18n
+                                            }
+                                            messages={preparedOptions.i18n}
+                                        >
+                                            <WidgetContainerThemeVariables
+                                                {...widgetAttrs}
+                                                className="r5-widget"
+                                            >
+                                                <Component
+                                                    {...preparedOptions}
+                                                />
+                                            </WidgetContainerThemeVariables>
+                                        </I18nProvider>
+                                    </ThemeProvider>
+                                </StyleSheetManager>
+                            </SessionProvider>
+                        </ReachfiveProvider>
+                    </ConfigProvider>
+                );
+            }
+        );
+    };
 }
 
-export interface CreateMultiViewWidgetProps<P, U> extends MultiViewWidgetProps<P, U> {}
+export interface CreateMultiViewWidgetProps<P, U>
+    extends MultiViewWidgetProps<P, U> {}
 
-export function createMultiViewWidget<P, U = P>({ prepare, ...params }: MultiViewWidgetProps<P, U>) {
+export function createMultiViewWidget<P, U = P>({
+    prepare,
+    ...params
+}: MultiViewWidgetProps<P, U>) {
     return createWidget<P, U>({
         component: multiViewWidget<P, U>(params),
         prepare,
-        noIntro: true
+        noIntro: true,
     });
 }
 
 export interface MultiViewWidgetProps<P, U> {
-    initialView: ((props: Omit<U, 'theme'>) => string) | string
-    views: Record<string, ComponentType<Omit<U, 'theme'>>>
-    initialState?: MultiWidgetState
-    prepare?: PrepareFn<P, U>
+    initialView: ((props: Omit<U, "theme">) => string) | string;
+    views: Record<string, ComponentType<Omit<U, "theme">>>;
+    initialState?: MultiWidgetState;
+    prepare?: PrepareFn<P, U>;
 }
 
 export type MultiWidgetState = Record<string, unknown> & {
-    activeView: string
-}
+    activeView: string;
+};
 
-function multiViewWidget<P, U>({ initialView, views, initialState = {} as MultiWidgetState }: MultiViewWidgetProps<P, U>) {
-    return class MultiViewWidget extends React.Component<Omit<U, 'theme'>, MultiWidgetState> {
-
+function multiViewWidget<P, U>({
+    initialView,
+    views,
+    initialState = {} as MultiWidgetState,
+}: MultiViewWidgetProps<P, U>) {
+    return class MultiViewWidget extends React.Component<
+        Omit<U, "theme">,
+        MultiWidgetState
+    > {
         state = {
             ...initialState,
-            activeView: typeof initialView === 'function' ? initialView(this.props) : initialView
+            activeView:
+                typeof initialView === "function"
+                    ? initialView(this.props)
+                    : initialView,
         };
 
         // _goTo = <View extends keyof typeof views, S extends ComponentProps<(typeof views)[View]>>(view: View, props?: S) => this.setState({
-        _goTo = <S extends Record<string, unknown>>(view: keyof typeof views, params?: S) => this.setState({
-            activeView: view as MultiWidgetState['activeView'],
-            ...params
-        });
+        _goTo = <S extends Record<string, unknown>>(
+            view: keyof typeof views,
+            params?: S
+        ) =>
+            this.setState({
+                activeView: view as MultiWidgetState["activeView"],
+                ...params,
+            });
 
         render() {
-            const { activeView, ...state } = this.state
+            const { activeView, ...state } = this.state;
             const ActiveComponent = views[activeView];
 
             return (
                 <RoutingProvider goTo={this._goTo} params={state}>
                     <ActiveComponent {...this.props} />
                 </RoutingProvider>
-            )
+            );
         }
-    }
+    };
 }

--- a/src/widgets/mfa/mfaListWidget.tsx
+++ b/src/widgets/mfa/mfaListWidget.tsx
@@ -1,66 +1,79 @@
-import React, {useEffect} from 'react';
-import { MFA } from '@reachfive/identity-core'
+import { MFA } from "@reachfive/identity-core";
+import React, { useEffect } from "react";
 
-import { createWidget } from '../../components/widget/widget';
+import { createWidget } from "../../components/widget/widget";
 
-import { useI18n } from '../../contexts/i18n';
-import { useConfig } from '../../contexts/config';
-import { dateFormat } from "../../helpers/utils.ts";
+import { LoaderCircle, Mail, MessageSquareMore, X } from "lucide-react";
 import {
     AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,
     AlertDialogContent,
+    AlertDialogDescription,
     AlertDialogFooter,
     AlertDialogHeader,
     AlertDialogTitle,
     AlertDialogTrigger,
-    AlertDialogDescription
-} from "../../components/ui/alert-dialog"
-import { Button } from "../../components/ui/button"
+} from "../../components/ui/alert-dialog";
+import { Button } from "../../components/ui/button";
+import { useConfig } from "../../contexts/config";
+import { useI18n } from "../../contexts/i18n";
 import { useReachfive } from "../../contexts/reachfive.tsx";
-import { X, MessageSquareMore, Mail, LoaderCircle } from "lucide-react";
-import { OnError, OnSuccess  } from "../../types";
+import { dateFormat } from "../../helpers/utils.ts";
+import { OnError, OnSuccess } from "../../types";
 
-const credentialIconByType = (type: MFA.CredentialsResponse['credentials'][number]['type']) => {
+const credentialIconByType = (
+    type: MFA.CredentialsResponse["credentials"][number]["type"]
+) => {
     switch (type) {
-        case 'email':
-            return <Mail className="bg-background w-icon h-icon stroke-textColor" />
-        case 'sms':
-            return <MessageSquareMore className="bg-background w-icon h-icon stroke-textColor" />
+        case "email":
+            return (
+                <Mail className="bg-background w-icon h-icon stroke-textColor" />
+            );
+        case "sms":
+            return (
+                <MessageSquareMore className="bg-background w-icon h-icon stroke-textColor" />
+            );
     }
-}
+};
 
 export interface MfaListProps {
     /**
      * The authorization credential JSON Web Token (JWT) used to access the ReachFive API, less than five minutes old.
      */
-    accessToken: string
+    accessToken: string;
     /**
      * Callback function called when the request has succeeded.
      */
-    onSuccess?: OnSuccess
+    onSuccess?: OnSuccess;
     /**
      * Callback function called when the request has failed.
      */
-    onError?: OnError
+    onError?: OnError;
     /**
      * Indicates whether delete mfa credential button is displayed
      */
-    showRemoveMfaCredential?: boolean
+    showRemoveMfaCredential?: boolean;
 }
 
 interface DeleteButtonProps {
-    credential: MFA.Credential
-    isOpen: boolean
-    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
-    onDeleteCallback: (credential: MFA.Credential) => void
-    deleteConfirmationTitle: string
-    setDeleteConfirmationTitle: React.Dispatch<React.SetStateAction<string>>
+    credential: MFA.Credential;
+    isOpen: boolean;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    onDeleteCallback: (credential: MFA.Credential) => void;
+    deleteConfirmationTitle: string;
+    setDeleteConfirmationTitle: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const DeleteButton = ({ credential, isOpen, setIsOpen, onDeleteCallback, deleteConfirmationTitle, setDeleteConfirmationTitle }: DeleteButtonProps) => {
-    const i18n = useI18n()
+const DeleteButton = ({
+    credential,
+    isOpen,
+    setIsOpen,
+    onDeleteCallback,
+    deleteConfirmationTitle,
+    setDeleteConfirmationTitle,
+}: DeleteButtonProps) => {
+    const i18n = useI18n();
 
     return (
         <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
@@ -69,7 +82,14 @@ const DeleteButton = ({ credential, isOpen, setIsOpen, onDeleteCallback, deleteC
                     variant="destructive"
                     size="icon"
                     className="ml-1"
-                    onClick={_ => setDeleteConfirmationTitle(credential.type === 'email' ? 'mfa.remove.email': 'mfa.remove.phoneNumber' )}>
+                    onClick={(_) =>
+                        setDeleteConfirmationTitle(
+                            credential.type === "email"
+                                ? "mfa.remove.email"
+                                : "mfa.remove.phoneNumber"
+                        )
+                    }
+                >
                     <X />
                 </Button>
             </AlertDialogTrigger>
@@ -81,116 +101,162 @@ const DeleteButton = ({ credential, isOpen, setIsOpen, onDeleteCallback, deleteC
                     <AlertDialogDescription />
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                    <AlertDialogCancel>{i18n('confirmation.cancel')}</AlertDialogCancel>
-                    <AlertDialogAction variant="destructive" onClick={_ => onDeleteCallback(credential)}>{i18n('confirmation.yes')}</AlertDialogAction>
+                    <AlertDialogCancel>
+                        {i18n("confirmation.cancel")}
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        variant="destructive"
+                        onClick={(_) => onDeleteCallback(credential)}
+                    >
+                        {i18n("confirmation.yes")}
+                    </AlertDialogAction>
                 </AlertDialogFooter>
             </AlertDialogContent>
         </AlertDialog>
-    )
-}
+    );
+};
 
 export const MfaList = ({
     accessToken,
     showRemoveMfaCredential,
     onError = (() => {}) as OnError,
-    onSuccess = (() => {}) as OnSuccess
-    }: MfaListProps) => {
-    const [isOpen, setIsOpen] = React.useState(false)
-    const [loading, setLoading] = React.useState(true)
-    const [deleteConfirmationTitle, setDeleteConfirmationTitle] = React.useState('')
-    const [credentials, setCredentials] = React.useState<MFA.Credential[]>([])
-    const i18n = useI18n()
-    const config = useConfig()
-    const client = useReachfive()
+    onSuccess = (() => {}) as OnSuccess,
+}: MfaListProps) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [loading, setLoading] = React.useState(true);
+    const [deleteConfirmationTitle, setDeleteConfirmationTitle] =
+        React.useState("");
+    const [credentials, setCredentials] = React.useState<MFA.Credential[]>([]);
+    const i18n = useI18n();
+    const config = useConfig();
+    const client = useReachfive();
 
     const fetchMfaCredentials = () => {
-        setLoading(true)
-        client.listMfaCredentials(accessToken)
-            .then(mfaCredentialsResponse => {
-                setCredentials(mfaCredentialsResponse.credentials)
-                onSuccess(mfaCredentialsResponse)
+        setLoading(true);
+        client
+            .listMfaCredentials(accessToken)
+            .then((mfaCredentialsResponse) => {
+                setCredentials(mfaCredentialsResponse.credentials);
+                onSuccess(mfaCredentialsResponse);
             })
             .catch(onError)
-            .finally(() => setLoading(false))
-    }
+            .finally(() => setLoading(false));
+    };
 
     useEffect(() => {
-        fetchMfaCredentials()
+        fetchMfaCredentials();
     }, [accessToken]);
 
     const onDelete = (credential: MFA.Credential) => {
         switch (credential.type) {
             case "sms":
-                client.removeMfaPhoneNumber({
-                    accessToken,
-                    phoneNumber: credential.phoneNumber
-                })
-                    .then(resp => {
-                        fetchMfaCredentials()
-                        onSuccess(resp)
+                client
+                    .removeMfaPhoneNumber({
+                        accessToken,
+                        phoneNumber: credential.phoneNumber,
                     })
-                    .catch(onError)
-                break
-            case 'email':
-                client.removeMfaEmail({accessToken})
-                    .then(resp => {
-                        fetchMfaCredentials()
-                        onSuccess(resp)
+                    .then((resp) => {
+                        fetchMfaCredentials();
+                        onSuccess(resp);
                     })
-                    .catch(onError)
-                break
+                    .catch(onError);
+                break;
+            case "email":
+                client
+                    .removeMfaEmail({ accessToken })
+                    .then((resp) => {
+                        fetchMfaCredentials();
+                        onSuccess(resp);
+                    })
+                    .catch(onError);
+                break;
         }
-    }
+    };
 
-    if(loading) {
-        return <LoaderCircle className="animate-spin" />
+    if (loading) {
+        return <LoaderCircle className="animate-spin" />;
     }
 
     return (
         <div>
-            {(credentials.length === 0) && (
-                <div className="text-textColor mb-1 text-center">{i18n('mfaList.noCredentials')}</div>
+            {credentials.length === 0 && (
+                <div className="mb-1 text-center text-textColor">
+                    {i18n("mfaList.noCredentials")}
+                </div>
             )}
             {credentials.map((credential, _) => (
-                <div id={`credential-${credential.friendlyName}`} data-testid="credential" key={`credential-${credential.friendlyName}`} className={`flex flex-col ${isOpen ? 'opacity-15' : ''}`}>
+                <div
+                    id={`credential-${credential.friendlyName}`}
+                    data-testid="credential"
+                    key={`credential-${credential.friendlyName}`}
+                    className={`flex flex-col ${isOpen ? "opacity-15" : ""}`}
+                >
                     <div className="flex flex-row items-center rounded">
-                        <div className="flex flex-row basis-full items-center rounded align-middle whitespace-nowrap box-border p-generic border-solid border" >
+                        <div className="box-border flex flex-row items-center align-middle border border-solid rounded basis-full whitespace-nowrap p-generic">
                             {credentialIconByType(credential.type)}
                             <div className="ml-innerBlock w-max justify-items-stretch text-textColor">
-                                <div className="font-bold">{credential.friendlyName}</div>
-                                <div>{MFA.isEmailCredential(credential) ? credential.email : MFA.isPhoneCredential(credential) ? credential.phoneNumber : 'N/A'}</div>
+                                <div className="font-bold">
+                                    {credential.friendlyName}
+                                </div>
                                 <div>
-                                    <span>{i18n('mfaList.createdAt')}&nbsp;: </span>
-                                    <time dateTime={credential.createdAt}>{dateFormat(credential.createdAt, config.language)}</time>
+                                    {MFA.isEmailCredential(credential)
+                                        ? credential.email
+                                        : MFA.isPhoneCredential(credential)
+                                        ? credential.phoneNumber
+                                        : "N/A"}
+                                </div>
+                                <div>
+                                    <span>
+                                        {i18n("mfaList.createdAt")}&nbsp;:{" "}
+                                    </span>
+                                    <time dateTime={credential.createdAt}>
+                                        {dateFormat(
+                                            credential.createdAt,
+                                            config.language
+                                        )}
+                                    </time>
                                 </div>
                             </div>
                         </div>
-                        {showRemoveMfaCredential && <DeleteButton isOpen={isOpen} setIsOpen={setIsOpen} onDeleteCallback={onDelete} deleteConfirmationTitle={deleteConfirmationTitle} setDeleteConfirmationTitle={setDeleteConfirmationTitle} credential={credential}/>}
+                        {showRemoveMfaCredential && (
+                            <DeleteButton
+                                isOpen={isOpen}
+                                setIsOpen={setIsOpen}
+                                onDeleteCallback={onDelete}
+                                deleteConfirmationTitle={
+                                    deleteConfirmationTitle
+                                }
+                                setDeleteConfirmationTitle={
+                                    setDeleteConfirmationTitle
+                                }
+                                credential={credential}
+                            />
+                        )}
                     </div>
                 </div>
             ))}
         </div>
     );
-}
+};
 
 export type MfaListWidgetProps = {
-     /**
+    /**
      * The authorization credential JSON Web Token (JWT) used to access the ReachFive API, less than five minutes old.
      */
-    accessToken: string
+    accessToken: string;
     /**
      * Callback function called when the request has succeeded.
      */
-    onSuccess?: OnSuccess
+    onSuccess?: OnSuccess;
     /**
      * Callback function called when the request has failed.
      */
-    onError?: OnError
+    onError?: OnError;
     /**
      * Indicates whether delete mfa credential button is displayed
      */
-    showRemoveMfaCredential?: boolean
-}
+    showRemoveMfaCredential?: boolean;
+};
 
 export default createWidget<MfaListWidgetProps, MfaListProps>({
     component: MfaList,

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,55 +1,54 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    important: '.r5-widget',
-    corePlugins: {
-        container: false,
-        preflight: false,
-    },
-    content: {
-        relative: true,
-        files: [
-            "./src/**/*.{js,ts,jsx,tsx}"
-        ]
-    },
-    theme: {
-        extend: {
-            colors: {
-                primary: {
-                    DEFAULT: "var(--color-primary)",
-                    foreground: "var(--color-primary)",
-                },
-                destructive: {
-                    DEFAULT: "var(--color-destructive)",
-                    foreground: "var(--color-destructive)",
-                },
-                background: "var(--color-background)",
-                border: "var(--color-border)",
-                theme: "var(--color-text)"
-            },
-            spacing: {
-              DEFAULT: "calc(var(--spacing)*1px)",
-            },
-            borderRadius: {
-                    DEFAULT: "calc(var(--radius)*1px)"
-            },
-            fontSize: {
-                generic: ['calc(var(--generic)*1px)', {lineHeight: '1.5'}],
-            },
-            width: {
-                icon: `calc(var(--font-generic)*2px)`
-            },
-            height: {
-                icon: "calc(var(--font-generic)*2px)"
-            },
-            padding: {
-                generic: "calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px) calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px)"//"calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px) calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px)",
-            },
-            margin: {
-                innerBlock: "calc(var(--spacing-block-inner-height)*1px)"
-            },
-            borderWidth: {
-                DEFAULT: "calc(var(--border-width)*1px)"
-            }
+  important: ".r5-widget",
+  corePlugins: {
+    container: false,
+    preflight: false,
+  },
+  content: {
+    relative: true,
+    files: ["./src/**/*.{js,ts,jsx,tsx}"],
+  },
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "var(--color-primary)",
+          foreground: "var(--color-primary)",
         },
+        destructive: {
+          DEFAULT: "var(--color-destructive)",
+          foreground: "var(--color-destructive)",
+        },
+        background: "var(--color-background)",
+        border: "var(--color-border)",
+        theme: "var(--color-text)",
+      },
+      spacing: {
+        DEFAULT: "calc(var(--spacing)*1px)",
+      },
+      borderRadius: {
+        DEFAULT: "calc(var(--radius)*1px)",
+      },
+      fontSize: {
+        generic: ["calc(var(--generic)*1px)", { lineHeight: "1.5" }],
+      },
+      width: {
+        icon: `calc(var(--font-generic)*2px)`,
+      },
+      height: {
+        icon: "calc(var(--font-generic)*2px)",
+      },
+      padding: {
+        generic:
+          "calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px) calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px)", //"calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px) calc(var(--spacing-padding-y)*1px) calc(var(--spacing-padding-x)*1px)",
+      },
+      margin: {
+        innerBlock: "calc(var(--spacing-block-inner-height)*1px)",
+      },
+      borderWidth: {
+        DEFAULT: "calc(var(--border-width)*1px)",
+      },
     },
+  },
 };

--- a/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.ts.snap
+++ b/tests/widgets/mfa/__snapshots__/MfaCredentialsWidget.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`Snapshot mfaCredentials default 1`] = `
 <div>
   <div
-    class="sc-imWYAI fLZoZn sc-jXbUNg dSJwGX r5-widget"
+    class="sc-imWYAI fLZoZn sc-dhKdcB lapPam r5-widget"
     transition="entering"
   >
     <div>
       <div
-        class="sc-ikkxIA cBvvMS"
+        class="sc-dAbbOL dAhtst"
       >
         <div>
           <div
@@ -17,11 +17,11 @@ exports[`Snapshot mfaCredentials default 1`] = `
             mfa.email.explain
           </div>
           <form
-            class="sc-fPXMVe eavqeI"
+            class="sc-gFqAkR lmligY"
             novalidate=""
           >
             <button
-              class="sc-eldPxv kznwvY"
+              class="sc-fPXMVe dsmqYT"
               data-testid="submit"
               type="submit"
             >
@@ -43,22 +43,22 @@ exports[`Snapshot mfaCredentials default 1`] = `
             mfa.phoneNumber.explain
           </div>
           <form
-            class="sc-fPXMVe eavqeI"
+            class="sc-gFqAkR lmligY"
             novalidate=""
           >
             <div
-              class="sc-jlZhew bzRqIF"
+              class="sc-cwHptR hcXvLx"
               required=""
             >
               <label
-                class="sc-kpDqfm gyyfze"
+                class="sc-dAlyuH ckDxcO"
                 for="phone_number"
               >
                 phoneNumber
               </label>
               <input
                 autocomplete="tel"
-                class="sc-cwHptR hTkSXX"
+                class="sc-jEACwC cqJTew"
                 data-testid="phone_number"
                 id="phone_number"
                 labels="[object Object]"
@@ -70,7 +70,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
               />
             </div>
             <button
-              class="sc-eldPxv kznwvY"
+              class="sc-fPXMVe dsmqYT"
               data-testid="submit"
               type="submit"
             >
@@ -80,7 +80,7 @@ exports[`Snapshot mfaCredentials default 1`] = `
         </div>
       </div>
       <div
-        class="sc-ikkxIA cBvvMS"
+        class="sc-dAbbOL dAhtst"
       />
     </div>
   </div>
@@ -90,23 +90,23 @@ exports[`Snapshot mfaCredentials default 1`] = `
 exports[`Snapshot mfaCredentials no intro 1`] = `
 <div>
   <div
-    class="sc-imWYAI fLZoZn sc-jXbUNg dSJwGX r5-widget"
+    class="sc-imWYAI fLZoZn sc-dhKdcB lapPam r5-widget"
     transition="entering"
   >
     <div>
       <div
-        class="sc-ikkxIA cBvvMS"
+        class="sc-dAbbOL dAhtst"
       />
       <div
-        class="sc-ikkxIA cBvvMS"
+        class="sc-dAbbOL dAhtst"
       >
         <div>
           <form
-            class="sc-fPXMVe eavqeI"
+            class="sc-gFqAkR lmligY"
             novalidate=""
           >
             <button
-              class="sc-eldPxv kznwvY"
+              class="sc-fPXMVe dsmqYT"
               data-testid="submit"
               type="submit"
             >
@@ -123,11 +123,11 @@ exports[`Snapshot mfaCredentials no intro 1`] = `
         </div>
         <div>
           <form
-            class="sc-fPXMVe eavqeI"
+            class="sc-gFqAkR lmligY"
             novalidate=""
           >
             <button
-              class="sc-eldPxv kznwvY"
+              class="sc-fPXMVe dsmqYT"
               data-testid="submit"
               type="submit"
             >

--- a/tests/widgets/mfa/__snapshots__/mfaListWidget.test.ts.snap
+++ b/tests/widgets/mfa/__snapshots__/mfaListWidget.test.ts.snap
@@ -45,7 +45,7 @@ exports[`Snapshot basic 1`] = `
           class="flex flex-row items-center rounded"
         >
           <div
-            class="flex flex-row basis-full items-center rounded align-middle whitespace-nowrap box-border p-generic border-solid border"
+            class="box-border flex flex-row items-center align-middle border border-solid rounded basis-full whitespace-nowrap p-generic"
           >
             <svg
               class="lucide lucide-message-square-more bg-background w-icon h-icon stroke-textColor"
@@ -86,7 +86,8 @@ exports[`Snapshot basic 1`] = `
               <div>
                 <span>
                   mfaList.createdAt
-                   : 
+                   :
+                   
                 </span>
                 <time
                   datetime="2022-09-21"
@@ -107,7 +108,7 @@ exports[`Snapshot basic 1`] = `
           class="flex flex-row items-center rounded"
         >
           <div
-            class="flex flex-row basis-full items-center rounded align-middle whitespace-nowrap box-border p-generic border-solid border"
+            class="box-border flex flex-row items-center align-middle border border-solid rounded basis-full whitespace-nowrap p-generic"
           >
             <svg
               class="lucide lucide-mail bg-background w-icon h-icon stroke-textColor"
@@ -146,7 +147,8 @@ exports[`Snapshot basic 1`] = `
               <div>
                 <span>
                   mfaList.createdAt
-                   : 
+                   :
+                   
                 </span>
                 <time
                   datetime="2022-09-21"
@@ -200,7 +202,7 @@ exports[`Snapshot empty 1`] = `
   >
     <div>
       <div
-        class="text-textColor mb-1 text-center"
+        class="mb-1 text-center text-textColor"
       >
         mfaList.noCredentials
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
 
     "baseUrl": ".",
     "paths": {
-        "@/*": ["./src/*"],
-        "@/lib": ["./src/lib/*"]
+      "@/*": ["./src/*"],
+      "@/lib": ["./src/lib/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "rollup.config.js", "tailwind.config.cjs"]
 }

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
- * @reachfive/identity-ui - v1.33.4-develop
- * Compiled Thu, 17 Apr 2025 11:59:25 UTC
+ * @reachfive/identity-ui - v1.33.3
+ * Compiled Mon, 12 May 2025 16:28:07 UTC
  *
  * Copyright (c) ReachFive.
  *
@@ -1520,8 +1520,8 @@ type MfaCredentialsWidgetProps = Prettify<Omit<MfaCredentialsProps, 'credentials
 
 type MfaListWidgetProps = {
     /**
-    * The authorization credential JSON Web Token (JWT) used to access the ReachFive API, less than five minutes old.
-    */
+     * The authorization credential JSON Web Token (JWT) used to access the ReachFive API, less than five minutes old.
+     */
     accessToken: string;
     /**
      * Callback function called when the request has succeeded.


### PR DESCRIPTION
### Added
- Allow to trust device during mfa credential registration

### Fixed

- Embed TailwindCSS utils in bundle
- Wrap dialog with theme provider (react portal)


### Problem

`Error: Can't resolve @/lib/utils` lors de l'importation du SDK dans un projet.
`@/lib/utils` contient des fonctions utilitaires pour Tailwind.
@sachaMemmir5 avait défini ce fichier dans le build Rollup comme "external", c'est à dire qu'il ne doit pas être embarqué dans le bundle généré mais de fait doit être importé de manière global par l'intégrateur. D'où l'erreur ci-dessus car l'intégrateur ne peux pas le savoir.
Le but de cette manœuvre était de régler un problème d'application des styles quand Sacha a testé ans Storybook l'intégration de Tailwind/Shadcn dans le SDK UI.
Après analyse je constate que ce problème venait non pas de `@/lib/utils` mais du fait que le composant `Dialog` de Shadcn utilisé par Sacha utilise un "Portal" React qui a la particularité d'injecté don rendu dans le body de la page et non pas dans l'arborescence du DOM où il est utilisé. De fait, le DOM de Dialog ne se retrouve pas wrappé par le provider du thème et des variables Tailwind custom.

### Solution

Wrapper le contenu du portail de la Dialog avec le même composant utilisé dans `Widget` pour wrapper un composant avec le `ThemeProvider` et les variables de theme custom.