### PR TITLE
Release v1.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.34.0] - 2025-05-13
+## [1.34.1] - 2025-05-15
+
+### Fixed
+
+- Reset password with phone number should send phone number value in payload
 
 ### Added
+
 - Allow to trust device during mfa credential registration
 
 ### Fixed
@@ -608,6 +613,8 @@ The eye icon is now correctly displayed in the Auth widget.
 First version of the SDK Web UI.
 
 [Unreleased]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.34.0...HEAD
+
+[1.34.1]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.34.0...v1.34.1
 
 [1.34.0]: https://github.com/ReachFive/identity-web-ui-sdk/compare/v1.33.2...v1.34.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.34.0",
+    "version": "1.34.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@reachfive/identity-ui",
-            "version": "1.34.0",
+            "version": "1.34.1",
             "license": "MIT",
             "dependencies": {
                 "@reachfive/identity-core": "^1.36.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reachfive/identity-ui",
-    "version": "1.34.0",
+    "version": "1.34.1",
     "description": "ReachFive Identity Web UI SDK",
     "author": "ReachFive",
     "repository": {

--- a/src/widgets/auth/views/forgotPasswordViewComponent.tsx
+++ b/src/widgets/auth/views/forgotPasswordViewComponent.tsx
@@ -1,27 +1,37 @@
-import React, { useCallback, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useLayoutEffect } from 'react'
 
 import { isAppError } from '../../../helpers/errors'
 
-import { email } from '../../../core/validation';
-import { Heading, Intro, Info, Link, Alternative } from '../../../components/miscComponent';
+import {
+    Alternative,
+    Heading,
+    Info,
+    Intro,
+    Link,
+} from '../../../components/miscComponent'
+import { email } from '../../../core/validation'
 
-import { createForm, FormContext } from '../../../components/form/formComponent';
-import phoneNumberField, { type PhoneNumberOptions } from '../../../components/form/fields/phoneNumberField';
-import { simpleField } from '../../../components/form/fields/simpleField';
-import ReCaptcha, {importGoogleRecaptchaScript} from '../../../components/reCaptcha';
+import phoneNumberField, {
+    type PhoneNumberOptions,
+} from '../../../components/form/fields/phoneNumberField'
+import { simpleField } from '../../../components/form/fields/simpleField'
+import { createForm, FormContext } from '../../../components/form/formComponent'
+import ReCaptcha, {
+    importGoogleRecaptchaScript,
+} from '../../../components/reCaptcha'
 
+import { InitialScreen } from '../../../../constants.ts'
+import { DefaultButton } from '../../../components/form/buttonComponent.tsx'
+import passwordField from '../../../components/form/fields/passwordField.tsx'
+import simplePasswordField from '../../../components/form/fields/simplePasswordField'
+import { useConfig } from '../../../contexts/config.tsx'
 import { useI18n } from '../../../contexts/i18n'
-import { useRouting } from '../../../contexts/routing';
-import { useReachfive } from '../../../contexts/reachfive';
-import { selectLogin } from '../authWidget.tsx';
-import { InitialScreen } from '../../../../constants.ts';
-import passwordField from '../../../components/form/fields/passwordField.tsx';
-import simplePasswordField from '../../../components/form/fields/simplePasswordField';
-import { DefaultButton } from '../../../components/form/buttonComponent.tsx';
-import { Validator } from '../../../core/validation.ts';
-import { useConfig } from '../../../contexts/config.tsx';
+import { useReachfive } from '../../../contexts/reachfive'
+import { useRouting } from '../../../contexts/routing'
+import { Validator } from '../../../core/validation.ts'
+import { selectLogin } from '../authWidget.tsx'
 
-import type { OnError, OnSuccess } from '../../../types';
+import type { OnError, OnSuccess } from '../../../types'
 
 type EmailIdentifier = { email: string }
 type PhoneNumberIdentifier = { phoneNumber: string }
@@ -42,27 +52,33 @@ const ForgotPasswordEmailForm = createForm<ForgotPasswordEmailFormData>({
             }),
         ]
     },
-    submitLabel: 'forgotPassword.submitLabel'
-});
+    submitLabel: 'forgotPassword.submitLabel',
+})
 
-const ForgotPasswordPhoneNumberForm = createForm<ForgotPasswordPhoneNumberFormData, { phoneNumberOptions?: PhoneNumberOptions }>({
+const ForgotPasswordPhoneNumberForm = createForm<
+    ForgotPasswordPhoneNumberFormData,
+    { phoneNumberOptions?: PhoneNumberOptions }
+>({
     prefix: 'r5-forgot-password-',
     fields({ config, phoneNumberOptions }) {
         return [
-            phoneNumberField({
-                key: 'phoneNumber',
-                label: 'phoneNumber',
-                required: true,
-                withCountryCallingCode: false,
-                ...phoneNumberOptions,
-            }, config)
+            phoneNumberField(
+                {
+                    key: 'phoneNumber',
+                    label: 'phoneNumber',
+                    required: true,
+                    withCountryCallingCode: false,
+                    ...phoneNumberOptions,
+                },
+                config
+            ),
         ]
     },
-    submitLabel: 'forgotPassword.submitLabel.code'
-});
+    submitLabel: 'forgotPassword.submitLabel.code',
+})
 
 export type VerificationCodeFormData = {
-    password: string,
+    password: string
     passwordConfirmation: string
     verificationCode: string
 }
@@ -75,34 +91,44 @@ interface VerificationCodeFormProps {
     canShowPassword?: boolean
 }
 
-const VerificationCodeForm = createForm<VerificationCodeFormData, VerificationCodeFormProps>({
+const VerificationCodeForm = createForm<
+    VerificationCodeFormData,
+    VerificationCodeFormProps
+>({
     prefix: 'r5-verification-code-',
     fields({ canShowPassword = false, config }) {
         return [
             simpleField({
                 key: 'verification_code',
                 label: 'verificationCode',
-                type: 'text'
+                type: 'text',
             }),
-            passwordField({
-                label: 'newPassword',
-                autoComplete: 'new-password',
-                canShowPassword
-            }, config),
+            passwordField(
+                {
+                    label: 'newPassword',
+                    autoComplete: 'new-password',
+                    canShowPassword,
+                },
+                config
+            ),
             simplePasswordField({
                 key: 'password_confirmation',
                 label: 'passwordConfirmation',
                 autoComplete: 'new-password',
-                validator: new Validator<string, FormContext<VerificationCodeFormData>>({
+                validator: new Validator<
+                    string,
+                    FormContext<VerificationCodeFormData>
+                >({
                     rule: (value, ctx) => value === ctx.fields.password,
-                    hint: 'passwordMatch'
-                })
-            })
+                    hint: 'passwordMatch',
+                }),
+            }),
         ]
-    }
+    },
 })
 
-const skipError = (error: unknown) => isAppError(error) ? error.error === 'resource_not_found' : false;
+const skipError = (error: unknown) =>
+    isAppError(error) ? error.error === 'resource_not_found' : false
 
 export interface ForgotPasswordViewProps {
     /**
@@ -155,12 +181,12 @@ export interface ForgotPasswordViewProps {
      * The URL sent in the email to which the user is redirected.
      * This URL must be whitelisted in the `Allowed Callback URLs` field of your ReachFive client settings.
      */
-    redirectUrl?: string,
+    redirectUrl?: string
     /**
      * Returned in the `redirectUrl` as a query parameter, this parameter is used to redirect users to a specific URL after a password reset.
      * Important: This parameter should only be used with Hosted Pages.
      */
-    returnToAfterPasswordReset?: string,
+    returnToAfterPasswordReset?: string
     /**
      * Callback function called when the request has succeed.
      */
@@ -193,13 +219,19 @@ export const ForgotPasswordView = ({
     const callback = useCallback(
         (data: ForgotPasswordEmailFormData) => {
             return ReCaptcha.handle(
-                {...data, redirectUrl, returnToAfterPasswordReset},
+                { ...data, redirectUrl, returnToAfterPasswordReset },
                 { recaptcha_enabled, recaptcha_site_key },
                 coreClient.requestPasswordReset,
-                "forgot_password"
+                'forgot_password'
             )
         },
-        [coreClient, recaptcha_enabled, recaptcha_site_key, redirectUrl, returnToAfterPasswordReset]
+        [
+            coreClient,
+            recaptcha_enabled,
+            recaptcha_site_key,
+            redirectUrl,
+            returnToAfterPasswordReset,
+        ]
     )
 
     useLayoutEffect(() => {
@@ -222,12 +254,20 @@ export const ForgotPasswordView = ({
             />
             {allowPhoneNumberResetPassword && config.sms && (
                 <Alternative>
-                    <DefaultButton onClick={() => goTo('forgot-password-phone-number')}>{i18n('forgotPassword.usePhoneNumberButton')}</DefaultButton>
+                    <DefaultButton
+                        onClick={() => goTo('forgot-password-phone-number')}
+                    >
+                        {i18n('forgotPassword.usePhoneNumberButton')}
+                    </DefaultButton>
                 </Alternative>
             )}
             {allowLogin && (
                 <Alternative>
-                    <Link target={selectLogin(initialScreen, allowWebAuthnLogin)}>{i18n('forgotPassword.backToLoginLink')}</Link>
+                    <Link
+                        target={selectLogin(initialScreen, allowWebAuthnLogin)}
+                    >
+                        {i18n('forgotPassword.backToLoginLink')}
+                    </Link>
                 </Alternative>
             )}
         </div>
@@ -251,22 +291,27 @@ export const ForgotPasswordPhoneNumberView = ({
     const { goTo } = useRouting()
     const i18n = useI18n()
 
-    const [phoneNumber, setPhoneNumber] = useState<string>('')
-    
     const callback = useCallback(
         (data: ForgotPasswordPhoneNumberFormData) => {
-            setPhoneNumber(data.phoneNumber)
             return ReCaptcha.handle(
-                {...data, redirectUrl, returnToAfterPasswordReset},
+                { ...data, redirectUrl, returnToAfterPasswordReset },
                 { recaptcha_enabled, recaptcha_site_key },
                 coreClient.requestPasswordReset,
-                "forgot_password"
-            )
+                'forgot_password'
+            ).then(() => data)
         },
-        [coreClient, recaptcha_enabled, recaptcha_site_key, redirectUrl, returnToAfterPasswordReset]
+        [
+            coreClient,
+            recaptcha_enabled,
+            recaptcha_site_key,
+            redirectUrl,
+            returnToAfterPasswordReset,
+        ]
     )
 
-    const onSuccess = () => goTo<PhoneNumberIdentifier>('forgot-password-code', { phoneNumber })
+    const onSuccess = ({ phoneNumber }: PhoneNumberIdentifier) => {
+        goTo<PhoneNumberIdentifier>('forgot-password-code', { phoneNumber })
+    }
 
     useLayoutEffect(() => {
         importGoogleRecaptchaScript(recaptcha_site_key)
@@ -285,11 +330,17 @@ export const ForgotPasswordPhoneNumberView = ({
                 phoneNumberOptions={phoneNumberOptions}
             />
             <Alternative>
-                <DefaultButton onClick={() => goTo('forgot-password')}>{i18n('forgotPassword.useEmailButton')}</DefaultButton>
+                <DefaultButton onClick={() => goTo('forgot-password')}>
+                    {i18n('forgotPassword.useEmailButton')}
+                </DefaultButton>
             </Alternative>
             {allowLogin && (
                 <Alternative>
-                    <Link target={selectLogin(initialScreen, allowWebAuthnLogin)}>{i18n('forgotPassword.backToLoginLink')}</Link>
+                    <Link
+                        target={selectLogin(initialScreen, allowWebAuthnLogin)}
+                    >
+                        {i18n('forgotPassword.backToLoginLink')}
+                    </Link>
                 </Alternative>
             )}
         </div>
@@ -306,13 +357,14 @@ export const ForgotPasswordCodeView = ({
     onSuccess = (() => {}) as OnSuccess,
 }: ForgotPasswordViewProps) => {
     const coreClient = useReachfive()
-    const { goTo, params } = useRouting()
     const i18n = useI18n()
+    const { goTo, params } = useRouting()
+    const { phoneNumber } = params as PhoneNumberIdentifier
 
     const callback = useCallback(
         ({ passwordConfirmation: _, ...data }: VerificationCodeFormData) => {
             return coreClient.updatePassword({
-                ...(params as PhoneNumberIdentifier),
+                phoneNumber,
                 ...data,
             })
         },
@@ -335,7 +387,11 @@ export const ForgotPasswordCodeView = ({
             />
             {allowLogin && (
                 <Alternative>
-                    <Link target={selectLogin(initialScreen, allowWebAuthnLogin)}>{i18n('back')}</Link>
+                    <Link
+                        target={selectLogin(initialScreen, allowWebAuthnLogin)}
+                    >
+                        {i18n('back')}
+                    </Link>
                 </Alternative>
             )}
         </div>
@@ -345,7 +401,7 @@ export const ForgotPasswordCodeView = ({
 export const ForgotPasswordSuccessView = ({
     allowLogin = true,
     initialScreen,
-    allowWebAuthnLogin = false
+    allowWebAuthnLogin = false,
 }: ForgotPasswordViewProps) => {
     const i18n = useI18n()
     return (
@@ -354,7 +410,11 @@ export const ForgotPasswordSuccessView = ({
             <Info>{i18n('forgotPassword.successMessage')}</Info>
             {allowLogin && (
                 <Alternative>
-                    <Link target={selectLogin(initialScreen, allowWebAuthnLogin)}>{i18n('back')}</Link>
+                    <Link
+                        target={selectLogin(initialScreen, allowWebAuthnLogin)}
+                    >
+                        {i18n('back')}
+                    </Link>
                 </Alternative>
             )}
         </div>

--- a/tests/widgets/auth/authWidget.test.ts
+++ b/tests/widgets/auth/authWidget.test.ts
@@ -2,20 +2,21 @@
  * @jest-environment jsdom
  */
 
-import { describe, expect, jest, test } from '@jest/globals';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, jest, test } from '@jest/globals'
 import '@testing-library/jest-dom/jest-globals'
-import 'jest-styled-components';
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import 'jest-styled-components'
 
-import type { PasswordStrengthScore, Client } from '@reachfive/identity-core';
+import type { Client, PasswordStrengthScore } from '@reachfive/identity-core'
 
-import { type I18nMessages } from '../../../src/core/i18n';
-import { type ProviderId, providers } from '../../../src/providers/providers';
-import type { Config } from '../../../src/types';
-import { randomString } from '../../../src/helpers/random';
+import { type I18nMessages } from '../../../src/core/i18n'
+import { randomString } from '../../../src/helpers/random'
+import { type ProviderId, providers } from '../../../src/providers/providers'
+import type { Config } from '../../../src/types'
 
-import authWidget from '../../../src/widgets/auth/authWidget';
-import { beforeEach } from 'node:test';
+import { beforeEach } from 'node:test'
+import authWidget from '../../../src/widgets/auth/authWidget'
 
 const defaultConfig: Config = {
     clientId: 'local',
@@ -35,48 +36,58 @@ const defaultConfig: Config = {
     consentsVersions: {
         aConsent: {
             key: 'aConsent',
-            versions: [{
-                versionId: 1,
-                title: 'consent title',
-                description: 'consent description',
-                language: 'fr',
-            }],
+            versions: [
+                {
+                    versionId: 1,
+                    title: 'consent title',
+                    description: 'consent description',
+                    language: 'fr',
+                },
+            ],
             consentType: 'opt-in',
-            status: 'active'
-        }
+            status: 'active',
+        },
     },
     passwordPolicy: {
         minLength: 8,
         minStrength: 2,
         allowUpdateWithAccessTokenOnly: true,
-    }
-};
+    },
+}
 
 const defaultI18n: I18nMessages = {}
 
-const webauthnConfig = { ...defaultConfig, webAuthn: true };
+const webauthnConfig = { ...defaultConfig, webAuthn: true }
 
 function expectSocialButtons(toBeInTheDocument = true) {
     return defaultConfig.socialProviders.forEach((provider) => {
         if (toBeInTheDocument) {
-            expect(screen.queryByTitle(providers[provider as ProviderId].name)).toBeInTheDocument()
+            expect(
+                screen.queryByTitle(providers[provider as ProviderId].name)
+            ).toBeInTheDocument()
         } else {
-            expect(screen.queryByTitle(providers[provider as ProviderId].name)).not.toBeInTheDocument()
+            expect(
+                screen.queryByTitle(providers[provider as ProviderId].name)
+            ).not.toBeInTheDocument()
         }
     })
 }
 
 describe('Snapshot', () => {
-    const getPasswordStrength = jest.fn<Client['getPasswordStrength']>().mockImplementation((password) => {
-        let score = 0
-        if (password.match(/[a-z]+/)) score++
-        if (password.match(/[0-9]+/)) score++
-        if (password.match(/[^a-z0-9]+/)) score++
-        if (password.length > 8) score++
-        return Promise.resolve({ score: score as PasswordStrengthScore })
-    })
-    
-    const loginWithWebAuthn = jest.fn<Client['loginWithWebAuthn']>().mockRejectedValue(new Error('This is a mock.'))
+    const getPasswordStrength = jest
+        .fn<Client['getPasswordStrength']>()
+        .mockImplementation((password) => {
+            let score = 0
+            if (password.match(/[a-z]+/)) score++
+            if (password.match(/[0-9]+/)) score++
+            if (password.match(/[^a-z0-9]+/)) score++
+            if (password.length > 8) score++
+            return Promise.resolve({ score: score as PasswordStrengthScore })
+        })
+
+    const loginWithWebAuthn = jest
+        .fn<Client['loginWithWebAuthn']>()
+        .mockRejectedValue(new Error('This is a mock.'))
 
     // @ts-expect-error partial Client
     const apiClient: Client = {
@@ -89,561 +100,853 @@ describe('Snapshot', () => {
         loginWithWebAuthn.mockClear()
     })
 
-    const generateSnapshot = (options: Parameters<typeof authWidget>[0] = {}, config: Partial<Config> = {}) => async () => {
-        const widget = await authWidget(options, {config: { ...defaultConfig, ...config }, apiClient, defaultI18n })
-                
-        await waitFor(async () => {
-            const { container } = await render(widget);
-            expect(container).toMatchSnapshot();
-        })
-    };
+    const generateSnapshot =
+        (
+            options: Parameters<typeof authWidget>[0] = {},
+            config: Partial<Config> = {}
+        ) =>
+        async () => {
+            const widget = await authWidget(options, {
+                config: { ...defaultConfig, ...config },
+                apiClient,
+                defaultI18n,
+            })
+
+            await waitFor(async () => {
+                const { container } = await render(widget)
+                expect(container).toMatchSnapshot()
+            })
+        }
 
     describe('login view', () => {
-        test('default', generateSnapshot({
-            allowWebAuthnLogin: false
-        }));
+        test(
+            'default',
+            generateSnapshot({
+                allowWebAuthnLogin: false,
+            })
+        )
 
-        test('no signup', generateSnapshot({
-            allowSignup: false
-        }));
+        test(
+            'no signup',
+            generateSnapshot({
+                allowSignup: false,
+            })
+        )
 
-        test('with remember me', generateSnapshot({
-            showRememberMe: true
-        }));
+        test(
+            'with remember me',
+            generateSnapshot({
+                showRememberMe: true,
+            })
+        )
 
-        test('with canShowPassword', generateSnapshot({
-            canShowPassword: true
-        }));
+        test(
+            'with canShowPassword',
+            generateSnapshot({
+                canShowPassword: true,
+            })
+        )
 
-        test('no forgot password', generateSnapshot({
-            allowForgotPassword: false
-        }));
+        test(
+            'no forgot password',
+            generateSnapshot({
+                allowForgotPassword: false,
+            })
+        )
 
-        test('inline social buttons', generateSnapshot({
-            theme: {
-                socialButton: {
-                    inline: true
-                }
-            }
-        }));
-    });
+        test(
+            'inline social buttons',
+            generateSnapshot({
+                theme: {
+                    socialButton: {
+                        inline: true,
+                    },
+                },
+            })
+        )
+    })
 
     describe('signup view', () => {
-        test('default', generateSnapshot({
-            initialScreen: 'signup'
-        }));
-
-        test('no login', generateSnapshot({
-            initialScreen: 'signup',
-            allowLogin: false
-        }));
-
-        test('show labels', generateSnapshot({
-            initialScreen: 'signup',
-            showLabels: true
-        }));
-
-        test('inline social buttons', generateSnapshot({
-            initialScreen: 'signup',
-            theme: {
-                socialButton: {
-                    inline: true
-                }
-            }
-        }));
-
-        test('with user agreement', generateSnapshot({
-            initialScreen: 'signup',
-            userAgreement: 'En vous inscrivant, vous acceptez les [conditions générales d\'utilisation](https://sandbox-local.reach5.co/).'
-        }));
-
-        test('with consents', generateSnapshot({
-            initialScreen: 'signup',
-            signupFields: ['email', 'password', 'consents.aConsent']
-        }));
-
-        test('with mandatory consents', generateSnapshot({
-            initialScreen: 'signup',
-            signupFields: ['email', 'password', { key: 'consents.aConsent', required: true }]
-        }));
-
-        test('with custom fields', generateSnapshot(
-            {
+        test(
+            'default',
+            generateSnapshot({
                 initialScreen: 'signup',
-                signupFields: ['email', 'password', 'custom_fields.newsletter_optin'],
-            },
-            {
-                ...defaultConfig,
-                customFields: [
-                    {
-                        id: 'newsletter_optin',
-                        name: 'Newsletter optin',
-                        path: 'newsletter_optin',
-                        dataType: 'checkbox'
-                    }
-                ]
-            }
-        ))
-    });
+            })
+        )
+
+        test(
+            'no login',
+            generateSnapshot({
+                initialScreen: 'signup',
+                allowLogin: false,
+            })
+        )
+
+        test(
+            'show labels',
+            generateSnapshot({
+                initialScreen: 'signup',
+                showLabels: true,
+            })
+        )
+
+        test(
+            'inline social buttons',
+            generateSnapshot({
+                initialScreen: 'signup',
+                theme: {
+                    socialButton: {
+                        inline: true,
+                    },
+                },
+            })
+        )
+
+        test(
+            'with user agreement',
+            generateSnapshot({
+                initialScreen: 'signup',
+                userAgreement:
+                    "En vous inscrivant, vous acceptez les [conditions générales d'utilisation](https://sandbox-local.reach5.co/).",
+            })
+        )
+
+        test(
+            'with consents',
+            generateSnapshot({
+                initialScreen: 'signup',
+                signupFields: ['email', 'password', 'consents.aConsent'],
+            })
+        )
+
+        test(
+            'with mandatory consents',
+            generateSnapshot({
+                initialScreen: 'signup',
+                signupFields: [
+                    'email',
+                    'password',
+                    { key: 'consents.aConsent', required: true },
+                ],
+            })
+        )
+
+        test(
+            'with custom fields',
+            generateSnapshot(
+                {
+                    initialScreen: 'signup',
+                    signupFields: [
+                        'email',
+                        'password',
+                        'custom_fields.newsletter_optin',
+                    ],
+                },
+                {
+                    ...defaultConfig,
+                    customFields: [
+                        {
+                            id: 'newsletter_optin',
+                            name: 'Newsletter optin',
+                            path: 'newsletter_optin',
+                            dataType: 'checkbox',
+                        },
+                    ],
+                }
+            )
+        )
+    })
 
     describe('with webauthn feature', () => {
-        test('login old view with webauthn or password', generateSnapshot({
-            allowWebAuthnLogin: true
-        }, webauthnConfig))
+        test(
+            'login old view with webauthn or password',
+            generateSnapshot(
+                {
+                    allowWebAuthnLogin: true,
+                },
+                webauthnConfig
+            )
+        )
 
-        test('login new view with integradted webauthn and password', generateSnapshot({
-            allowWebAuthnLogin: true,
-            initialScreen: 'login'
-        }, webauthnConfig))
+        test(
+            'login new view with integradted webauthn and password',
+            generateSnapshot(
+                {
+                    allowWebAuthnLogin: true,
+                    initialScreen: 'login',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup view with webauthn or password', generateSnapshot({
-            allowWebAuthnSignup: true,
-            initialScreen: 'signup'
-        }, webauthnConfig))
+        test(
+            'signup view with webauthn or password',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    initialScreen: 'signup',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup form view with password', generateSnapshot({
-            allowWebAuthnSignup: true,
-            initialScreen: 'signup-with-password'
-        }, webauthnConfig))
+        test(
+            'signup form view with password',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    initialScreen: 'signup-with-password',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup form view with webauthn', generateSnapshot({
-            allowWebAuthnSignup: true,
-            initialScreen: 'signup-with-web-authn'
-        }, webauthnConfig))
+        test(
+            'signup form view with webauthn',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    initialScreen: 'signup-with-web-authn',
+                },
+                webauthnConfig
+            )
+        )
     })
 
     describe('with webauthn feature and without password', () => {
-        test('login old view with webauthn or password', generateSnapshot({
-            allowWebAuthnLogin: true,
-            enablePasswordAuthentication:false
-        }, webauthnConfig))
+        test(
+            'login old view with webauthn or password',
+            generateSnapshot(
+                {
+                    allowWebAuthnLogin: true,
+                    enablePasswordAuthentication: false,
+                },
+                webauthnConfig
+            )
+        )
 
-        test('login new view with integrated webauthn and password', generateSnapshot({
-            allowWebAuthnLogin: true,
-            enablePasswordAuthentication:false,
-            initialScreen: 'login'
-        }, webauthnConfig))
+        test(
+            'login new view with integrated webauthn and password',
+            generateSnapshot(
+                {
+                    allowWebAuthnLogin: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'login',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup view with webauthn or password', generateSnapshot({
-            allowWebAuthnSignup: true,
-            enablePasswordAuthentication:false,
-            initialScreen: 'signup'
-        }, webauthnConfig))
+        test(
+            'signup view with webauthn or password',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup form view with password', generateSnapshot({
-            allowWebAuthnSignup: true,
-            enablePasswordAuthentication:false,
-            initialScreen: 'signup-with-password'
-        }, webauthnConfig))
+        test(
+            'signup form view with password',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup-with-password',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup form view with webauthn', generateSnapshot({
-            allowWebAuthnSignup: true,
-            enablePasswordAuthentication:false,
-            initialScreen: 'signup-with-web-authn'
-        }, webauthnConfig))
+        test(
+            'signup form view with webauthn',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup-with-web-authn',
+                },
+                webauthnConfig
+            )
+        )
 
-        test('signup form view with webauthn and without password', generateSnapshot({
-            allowWebAuthnSignup: true,
-            enablePasswordAuthentication: false,
-            initialScreen: 'signup-with-web-authn'
-        }, webauthnConfig))
+        test(
+            'signup form view with webauthn and without password',
+            generateSnapshot(
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup-with-web-authn',
+                },
+                webauthnConfig
+            )
+        )
     })
 
     describe('forgot password view', () => {
-        test('default', generateSnapshot({
-            initialScreen: 'forgot-password'
-        }));
-    });
-});
+        test(
+            'default',
+            generateSnapshot({
+                initialScreen: 'forgot-password',
+            })
+        )
+    })
+})
 
 describe('DOM testing', () => {
-    const getPasswordStrength = jest.fn<Client['getPasswordStrength']>().mockImplementation((password) => {
-        let score = 0
-        if (password.match(/[a-z]+/)) score++
-        if (password.match(/[0-9]+/)) score++
-        if (password.match(/[^a-z0-9]+/)) score++
-        if (password.length > 8) score++
-        return Promise.resolve({ score: score as PasswordStrengthScore })
-    })
-    
-    const loginWithWebAuthn = jest.fn<Client['loginWithWebAuthn']>().mockRejectedValue(new Error('This is a mock.'))
+    const getPasswordStrength = jest
+        .fn<Client['getPasswordStrength']>()
+        .mockImplementation((password) => {
+            let score = 0
+            if (password.match(/[a-z]+/)) score++
+            if (password.match(/[0-9]+/)) score++
+            if (password.match(/[^a-z0-9]+/)) score++
+            if (password.length > 8) score++
+            return Promise.resolve({ score: score as PasswordStrengthScore })
+        })
+
+    const loginWithWebAuthn = jest
+        .fn<Client['loginWithWebAuthn']>()
+        .mockRejectedValue(new Error('This is a mock.'))
+
+    const requestPasswordReset = jest
+        .fn<Client['requestPasswordReset']>()
+        .mockResolvedValue()
+
+    const updatePassword = jest
+        .fn<Client['updatePassword']>()
+        .mockResolvedValue()
 
     beforeEach(() => {
         getPasswordStrength.mockClear()
         loginWithWebAuthn.mockClear()
+        requestPasswordReset.mockClear()
+        updatePassword.mockClear()
     })
-    
-    const generateComponent = async (options: Parameters<typeof authWidget>[0] = {}, config: Partial<Config> = {}) => {
+
+    const generateComponent = async (
+        options: Parameters<typeof authWidget>[0] = {},
+        config: Partial<Config> = {}
+    ) => {
         // @ts-expect-error partial Client
         const apiClient: Client = {
             getPasswordStrength,
-            loginWithWebAuthn
+            loginWithWebAuthn,
+            requestPasswordReset,
+            updatePassword,
         }
-        const result = await authWidget(options, {config: { ...defaultConfig, ...config }, apiClient, defaultI18n });
-        return render(result);
-    };
+        const result = await authWidget(options, {
+            config: { ...defaultConfig, ...config },
+            apiClient,
+            defaultI18n,
+        })
+        return render(result)
+    }
 
     describe('login view', () => {
         test('default config', async () => {
-            expect.assertions(6);
-            await generateComponent({});
+            expect.assertions(6)
+            await generateComponent({})
 
             // Form button
-            expect(screen.queryByText('login.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('login.submitLabel')).toBeInTheDocument()
 
             // Links
-            expect(screen.queryByText('login.forgotPasswordLink')).toBeInTheDocument();
-            expect(screen.queryByText('login.signupLink')).toBeInTheDocument();
+            expect(
+                screen.queryByText('login.forgotPasswordLink')
+            ).toBeInTheDocument()
+            expect(screen.queryByText('login.signupLink')).toBeInTheDocument()
 
             // Social buttons
             expectSocialButtons(true)
 
             // No remember me
-            expect(screen.queryByTestId('auth.persistent')).not.toBeInTheDocument();
-        });
+            expect(
+                screen.queryByTestId('auth.persistent')
+            ).not.toBeInTheDocument()
+        })
 
         test('login only', async () => {
-            expect.assertions(2);
-            await generateComponent({
-                allowSignup: false
-            });
-
-            expect(screen.queryByText('login.forgotPasswordLink')).toBeInTheDocument();
-            expect(screen.queryByText('login.signupLinkk')).not.toBeInTheDocument();
-        });
-
-        test('without forgot password', async () => {
-            expect.assertions(3);
+            expect.assertions(2)
             await generateComponent({
                 allowSignup: false,
-                allowForgotPassword: false
-            });
+            })
+
+            expect(
+                screen.queryByText('login.forgotPasswordLink')
+            ).toBeInTheDocument()
+            expect(
+                screen.queryByText('login.signupLinkk')
+            ).not.toBeInTheDocument()
+        })
+
+        test('without forgot password', async () => {
+            expect.assertions(3)
+            await generateComponent({
+                allowSignup: false,
+                allowForgotPassword: false,
+            })
 
             expectSocialButtons(true)
 
-            expect(screen.queryByText('login.forgotPasswordLink')).not.toBeInTheDocument();
-        });
+            expect(
+                screen.queryByText('login.forgotPasswordLink')
+            ).not.toBeInTheDocument()
+        })
 
         test('with remember me', async () => {
-            expect.assertions(1);
+            expect.assertions(1)
             await generateComponent({
-                showRememberMe: true
-            });
+                showRememberMe: true,
+            })
 
-            expect(screen.queryByLabelText('rememberMe')).toBeInTheDocument();
-        });
+            expect(screen.queryByLabelText('rememberMe')).toBeInTheDocument()
+        })
 
         test('with canShowPassword', async () => {
-            expect.assertions(1);
+            expect.assertions(1)
             await generateComponent({
-                canShowPassword: true
-            });
+                canShowPassword: true,
+            })
 
             const password = screen.getByTestId('password')
-            expect(password.parentElement?.querySelector('svg')).toBeInTheDocument();
-        });
+            expect(
+                password.parentElement?.querySelector('svg')
+            ).toBeInTheDocument()
+        })
 
         test('inline social buttons', async () => {
-            expect.assertions(2);
+            expect.assertions(2)
             await generateComponent({
                 theme: {
                     socialButton: {
-                        inline: true
-                    }
-                }
-            });
+                        inline: true,
+                    },
+                },
+            })
 
             // Social buttons
             expectSocialButtons(true)
-        });
+        })
 
         describe('i18n', () => {
             test('overwrite title', async () => {
-                expect.assertions(1);
-                const title = randomString();
+                expect.assertions(1)
+                const title = randomString()
                 await generateComponent({
                     i18n: {
-                        'login.title': title
-                    }
-                });
+                        'login.title': title,
+                    },
+                })
 
-                expect(screen.queryByText(title)).toBeInTheDocument();
-            });
+                expect(screen.queryByText(title)).toBeInTheDocument()
+            })
 
             test('overwrite title - expanded', async () => {
-                expect.assertions(1);
-                const title = randomString();
+                expect.assertions(1)
+                const title = randomString()
                 await generateComponent({
                     i18n: {
                         login: {
-                            title
-                        }
-                    }
-                });
+                            title,
+                        },
+                    },
+                })
 
-                expect(screen.queryByText(title)).toBeInTheDocument();
-            });
-        });
-    });
+                expect(screen.queryByText(title)).toBeInTheDocument()
+            })
+        })
+    })
 
     describe('signup view', () => {
         test('default config', async () => {
-            expect.assertions(4);
+            expect.assertions(4)
             await generateComponent({
-                initialScreen: 'signup'
-            });
+                initialScreen: 'signup',
+            })
 
             // Form button
-            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument()
 
             // Login link
-            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument();
+            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument()
 
             // Social buttons
             expectSocialButtons(true)
-        });
+        })
 
         test('inline social buttons', async () => {
-            expect.assertions(2);
+            expect.assertions(2)
             await generateComponent({
                 initialScreen: 'signup',
                 theme: {
                     socialButton: {
-                        inline: true
-                    }
-                }
-            });
+                        inline: true,
+                    },
+                },
+            })
 
             // Social buttons
             expectSocialButtons(true)
-        });
+        })
 
         test('with user agreement', async () => {
-            expect.assertions(1);
+            expect.assertions(1)
             await generateComponent({
                 initialScreen: 'signup',
-                userAgreement: 'I agreed [terms of use](https://example.com/termsofuse).'
-            });
+                userAgreement:
+                    'I agreed [terms of use](https://example.com/termsofuse).',
+            })
 
-            expect(screen.queryByText('terms of use')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('terms of use')).toBeInTheDocument()
+        })
 
         test('default signup fields', async () => {
-            expect.assertions(5);
+            expect.assertions(5)
             await generateComponent({
-                initialScreen: 'signup'
-            });
+                initialScreen: 'signup',
+            })
 
             // form inputs
-            expect(screen.queryByTestId('givenName')).toBeInTheDocument();
-            expect(screen.queryByTestId('familyName')).toBeInTheDocument();
-            expect(screen.queryByTestId('email')).toBeInTheDocument();
-            expect(screen.queryByTestId('password')).toBeInTheDocument();
-            expect(screen.queryByTestId('passwordConfirmation')).toBeInTheDocument();
-        });
+            expect(screen.queryByTestId('givenName')).toBeInTheDocument()
+            expect(screen.queryByTestId('familyName')).toBeInTheDocument()
+            expect(screen.queryByTestId('email')).toBeInTheDocument()
+            expect(screen.queryByTestId('password')).toBeInTheDocument()
+            expect(
+                screen.queryByTestId('passwordConfirmation')
+            ).toBeInTheDocument()
+        })
 
         test('signup fields selection', async () => {
-            expect.assertions(3);
-            const signupFields = ['email', 'password', 'passwordConfirmation'];
+            expect.assertions(3)
+            const signupFields = ['email', 'password', 'passwordConfirmation']
             await generateComponent({
                 initialScreen: 'signup',
-                signupFields
-            });
+                signupFields,
+            })
 
-            signupFields.forEach(field => {
-                expect(screen.queryByTestId(field)).toBeInTheDocument();
-            });
-        });
+            signupFields.forEach((field) => {
+                expect(screen.queryByTestId(field)).toBeInTheDocument()
+            })
+        })
 
         test('signup fields selection with custom field', async () => {
-            expect.assertions(3);
-            const signupFields = ['email', 'password', 'custom_fields.newsletter_optin'];
-            await generateComponent({
-                initialScreen: 'signup',
-                signupFields
-            }, {
-                ...defaultConfig,
-                customFields: [
-                    {
-                        id: 'newsletter_optin',
-                        name: 'Newsletter optin',
-                        path: 'newsletter_optin',
-                        dataType: 'checkbox'
-                    }
-                ]
-            });
+            expect.assertions(3)
+            const signupFields = [
+                'email',
+                'password',
+                'custom_fields.newsletter_optin',
+            ]
+            await generateComponent(
+                {
+                    initialScreen: 'signup',
+                    signupFields,
+                },
+                {
+                    ...defaultConfig,
+                    customFields: [
+                        {
+                            id: 'newsletter_optin',
+                            name: 'Newsletter optin',
+                            path: 'newsletter_optin',
+                            dataType: 'checkbox',
+                        },
+                    ],
+                }
+            )
 
-            expect(screen.queryByTestId('email')).toBeInTheDocument();
-            expect(screen.queryByTestId('password')).toBeInTheDocument();
-            expect(screen.queryByTestId('custom_fields.newsletter_optin')).toBeInTheDocument();
-        });
-    });
+            expect(screen.queryByTestId('email')).toBeInTheDocument()
+            expect(screen.queryByTestId('password')).toBeInTheDocument()
+            expect(
+                screen.queryByTestId('custom_fields.newsletter_optin')
+            ).toBeInTheDocument()
+        })
+    })
 
     describe('with webauthn feature', () => {
         test('new login view', async () => {
-            expect.assertions(6);
+            expect.assertions(6)
 
             loginWithWebAuthn.mockRejectedValue(new Error('This is a mock.'))
 
-            await generateComponent({ allowWebAuthnLogin: true, initialScreen: 'login' }, webauthnConfig);
+            await generateComponent(
+                { allowWebAuthnLogin: true, initialScreen: 'login' },
+                webauthnConfig
+            )
 
             // Social buttons
             expectSocialButtons(true)
 
             // Email input
-            expect(screen.queryByTestId('identifier')).toBeInTheDocument();
+            expect(screen.queryByTestId('identifier')).toBeInTheDocument()
 
             // Form button
-            expect(screen.queryByText('login.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('login.submitLabel')).toBeInTheDocument()
 
             // Links
-            expect(screen.queryByText('login.forgotPasswordLink')).toBeInTheDocument();
+            expect(
+                screen.queryByText('login.forgotPasswordLink')
+            ).toBeInTheDocument()
 
             // Sign in link
-            expect(screen.queryByText('login.signupLink')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('login.signupLink')).toBeInTheDocument()
+        })
 
         test('old login view', async () => {
-            expect.assertions(6);
+            expect.assertions(6)
 
             loginWithWebAuthn.mockRejectedValue(new Error('This is a mock.'))
 
-            await generateComponent({ allowWebAuthnLogin: true, initialScreen: 'login-with-web-authn' }, webauthnConfig);
+            await generateComponent(
+                {
+                    allowWebAuthnLogin: true,
+                    initialScreen: 'login-with-web-authn',
+                },
+                webauthnConfig
+            )
 
             // Social buttons
             expectSocialButtons(true)
 
             // Email input
-            expect(screen.queryByTestId('identifier')).toBeInTheDocument();
+            expect(screen.queryByTestId('identifier')).toBeInTheDocument()
 
             // Form buttons
-            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument();
-            expect(screen.queryByTestId('password-button')).toBeInTheDocument();
+            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument()
+            expect(screen.queryByTestId('password-button')).toBeInTheDocument()
 
             // Sign in link
-            expect(screen.queryByText('login.signupLink')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('login.signupLink')).toBeInTheDocument()
+        })
 
         test('signup view with password or webauthn', async () => {
-            expect.assertions(5);
+            expect.assertions(5)
             await generateComponent(
-                { allowWebAuthnSignup: true,  initialScreen: 'signup' },
+                { allowWebAuthnSignup: true, initialScreen: 'signup' },
                 webauthnConfig
-            );
+            )
 
             // Social buttons
             expectSocialButtons(true)
 
             // Form buttons
-            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument();
-            expect(screen.queryByTestId('password-button')).toBeInTheDocument();
+            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument()
+            expect(screen.queryByTestId('password-button')).toBeInTheDocument()
 
             // Login in link
-            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument()
+        })
 
         test('signup form view with password', async () => {
-            expect.assertions(7);
+            expect.assertions(7)
             await generateComponent(
-                { allowWebAuthnSignup: true,  initialScreen: 'signup-with-password' },
+                {
+                    allowWebAuthnSignup: true,
+                    initialScreen: 'signup-with-password',
+                },
                 webauthnConfig
-            );
+            )
 
             // Form fields
-            expect(screen.queryByTestId('givenName')).toBeInTheDocument();
-            expect(screen.queryByTestId('familyName')).toBeInTheDocument();
-            expect(screen.queryByTestId('email')).toBeInTheDocument();
-            expect(screen.queryByTestId('password')).toBeInTheDocument();
-            expect(screen.queryByTestId('passwordConfirmation')).toBeInTheDocument();
+            expect(screen.queryByTestId('givenName')).toBeInTheDocument()
+            expect(screen.queryByTestId('familyName')).toBeInTheDocument()
+            expect(screen.queryByTestId('email')).toBeInTheDocument()
+            expect(screen.queryByTestId('password')).toBeInTheDocument()
+            expect(
+                screen.queryByTestId('passwordConfirmation')
+            ).toBeInTheDocument()
 
             // Form button
-            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument()
 
             // Back link
-            expect(screen.queryByText('back')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('back')).toBeInTheDocument()
+        })
 
         test('signup form view with webauthn', async () => {
-            expect.assertions(5);
+            expect.assertions(5)
             await generateComponent(
-                { allowWebAuthnSignup: true,  initialScreen: 'signup-with-web-authn' },
+                {
+                    allowWebAuthnSignup: true,
+                    initialScreen: 'signup-with-web-authn',
+                },
                 webauthnConfig
-            );
+            )
 
             // Form fields
-            expect(screen.queryByTestId('givenName')).toBeInTheDocument();
-            expect(screen.queryByTestId('familyName')).toBeInTheDocument();
-            expect(screen.queryByTestId('email')).toBeInTheDocument();
+            expect(screen.queryByTestId('givenName')).toBeInTheDocument()
+            expect(screen.queryByTestId('familyName')).toBeInTheDocument()
+            expect(screen.queryByTestId('email')).toBeInTheDocument()
 
             // Form button
-            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument()
 
             // Back link
-            expect(screen.queryByText('back')).toBeInTheDocument();
-        });
-    });
+            expect(screen.queryByText('back')).toBeInTheDocument()
+        })
+    })
 
     describe('with webauthn feature and without password', () => {
         test('old login view', async () => {
-            expect.assertions(6);
+            expect.assertions(6)
 
             loginWithWebAuthn.mockRejectedValue(new Error('This is a mock.'))
 
-            await generateComponent({
-                allowWebAuthnLogin: true,
-                enablePasswordAuthentication:false,
-                initialScreen: 'login-with-web-authn'
-            }, webauthnConfig);
+            await generateComponent(
+                {
+                    allowWebAuthnLogin: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'login-with-web-authn',
+                },
+                webauthnConfig
+            )
 
             // Social buttons
             expectSocialButtons(true)
 
             // Email input
-            expect(screen.queryByTestId('identifier')).toBeInTheDocument();
+            expect(screen.queryByTestId('identifier')).toBeInTheDocument()
 
             // Form buttons
-            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument();
-            expect(screen.queryByTestId('password-button')).toBeNull();
+            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument()
+            expect(screen.queryByTestId('password-button')).toBeNull()
 
             // Sign in link
-            expect(screen.queryByText('login.signupLink')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('login.signupLink')).toBeInTheDocument()
+        })
 
         test('signup view without password and with webauthn', async () => {
-            expect.assertions(5);
+            expect.assertions(5)
             await generateComponent(
-                { allowWebAuthnSignup: true,  enablePasswordAuthentication:false, initialScreen: 'signup' },
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup',
+                },
                 webauthnConfig
-            );
+            )
 
             // Social buttons
             expectSocialButtons(true)
 
             // Form buttons
-            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument();
-            expect(screen.queryByTestId('password-button')).toBeNull();
+            expect(screen.queryByTestId('webauthn-button')).toBeInTheDocument()
+            expect(screen.queryByTestId('password-button')).toBeNull()
 
             // Login in link
-            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('signup.loginLink')).toBeInTheDocument()
+        })
 
         test('signup form view with webauthn and without password', async () => {
-            expect.assertions(5);
+            expect.assertions(5)
             await generateComponent(
-                { allowWebAuthnSignup: true, enablePasswordAuthentication:false, initialScreen: 'signup-with-web-authn' },
+                {
+                    allowWebAuthnSignup: true,
+                    enablePasswordAuthentication: false,
+                    initialScreen: 'signup-with-web-authn',
+                },
                 webauthnConfig
-            );
+            )
 
             // Form fields
-            expect(screen.queryByTestId('givenName')).toBeInTheDocument();
-            expect(screen.queryByTestId('familyName')).toBeInTheDocument();
-            expect(screen.queryByTestId('email')).toBeInTheDocument();
+            expect(screen.queryByTestId('givenName')).toBeInTheDocument()
+            expect(screen.queryByTestId('familyName')).toBeInTheDocument()
+            expect(screen.queryByTestId('email')).toBeInTheDocument()
 
             // Form button
-            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument();
+            expect(screen.queryByText('signup.submitLabel')).toBeInTheDocument()
 
             // Back link
-            expect(screen.queryByText('back')).toBeInTheDocument();
-        });
+            expect(screen.queryByText('back')).toBeInTheDocument()
+        })
     })
-});
+
+    describe('forgot password', () => {
+        const user = userEvent.setup()
+
+        test('default', async () => {
+            await generateComponent({ initialScreen: 'forgot-password' })
+
+            const emailField = screen.getByLabelText('email')
+            const useEmailButton = screen.getByRole('button', {
+                name: 'forgotPassword.submitLabel',
+            })
+
+            await user.type(emailField, 'test@example.com')
+            await user.click(useEmailButton)
+
+            expect(requestPasswordReset).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    email: 'test@example.com',
+                })
+            )
+
+            expect(
+                screen.getByText('forgotPassword.successMessage')
+            ).toBeInTheDocument()
+        })
+
+        test('with phone number reset password', async () => {
+            await generateComponent(
+                {
+                    initialScreen: 'forgot-password',
+                    allowPhoneNumberResetPassword: true,
+                },
+                {
+                    countryCode: 'FR',
+                    sms: true,
+                }
+            )
+
+            const usePhoneNumberButton = screen.getByRole('button', {
+                name: 'forgotPassword.usePhoneNumberButton',
+            })
+
+            await user.click(usePhoneNumberButton)
+
+            expect(
+                screen.queryByText('forgotPassword.prompt.phoneNumber')
+            ).toBeInTheDocument()
+
+            const phoneNumberField = screen.getByLabelText('phoneNumber')
+            const submitPhoneNumberButton = screen.getByRole('button', {
+                name: 'forgotPassword.submitLabel.code',
+            })
+
+            await user.type(phoneNumberField, '0123456789')
+            await user.click(submitPhoneNumberButton)
+
+            expect(requestPasswordReset).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    phoneNumber: '+33123456789',
+                })
+            )
+
+            const verificationCodeField =
+                screen.getByLabelText('verificationCode')
+            const passwordField = screen.getByLabelText('newPassword')
+            const passwordConfirmationField = screen.getByLabelText(
+                'passwordConfirmation'
+            )
+            const sendCodeButton = screen.getByRole('button', {
+                name: 'send',
+            })
+
+            await user.type(verificationCodeField, '123456')
+            await user.type(passwordField, 'Wond3rFu11_Pa55w0rD*$')
+            await user.type(passwordConfirmationField, 'Wond3rFu11_Pa55w0rD*$')
+            await user.click(sendCodeButton)
+
+            expect(updatePassword).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    password: 'Wond3rFu11_Pa55w0rD*$',
+                    phoneNumber: '+33123456789',
+                    verificationCode: '123456',
+                })
+            )
+        })
+    })
+})

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
- * @reachfive/identity-ui - v1.33.3
- * Compiled Mon, 12 May 2025 16:28:07 UTC
+ * @reachfive/identity-ui - v1.34.1
+ * Compiled Thu, 15 May 2025 15:22:32 UTC
  *
  * Copyright (c) ReachFive.
  *


### PR DESCRIPTION
[CA-4936](https://reach5.atlassian.net/browse/CA-4936)

### Fixed

- Reset password with phone number should send phone number value in payload


La problème bien de la transimision  du phoneNumber entre la vue `ForgotPasswordPhoneNumberView` et `ForgotPasswordCodeView` lié à la mauvaise utilisation d'une valeur de state React dans callback `onSuccess`. Le state n'étant pas encore mis à jour dans le workflow de React (appel de `setPhoneNumber` dans la méthode `callback`) lors de l'appel à `onSuccess`.

Désolé,  pas mal de code formatting automatique lié à une petite reconfiguration de mes settings sur VSCode.

[CA-4936]: https://reach5.atlassian.net/browse/CA-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ