### PR TITLE
Fix bundle generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export type * from './main';
+export { createClient } from './main';
 export type { ThemeOptions } from './types/styled';
 import './index.css';


### PR DESCRIPTION
Corrige une regression apportée par l'ajout de Prettier qui a fait sauter l'export de la méthode `createClient` et donc sa disparition pure et simple du bundle généré 😱 