### PR TITLE
[CA-306] [CA-1183] Add address fields in Signup and ProfileEditor

### DIFF
--- a/src/components/form/fieldCreator.tsx
+++ b/src/components/form/fieldCreator.tsx
@@ -2,7 +2,7 @@ import React, { type ComponentType } from 'react';
 
 import type { WithI18n } from '../../contexts/i18n';
 import type { I18nResolver } from '../../core/i18n';
-import { PathMapping } from '../../core/mapping';
+import { DefaultPathMapping, type PathMapping } from '../../core/mapping';
 import {
     empty as emptyRule,
     isValidatorSuccess,
@@ -91,6 +91,7 @@ export type FieldDefinition<T, F = T, K extends string = 'raw'> = {
     defaultValue?: T;
     format?: Formatter<T, F, K>;
     validator?: Validator<F, any> | CompoundValidator<F, any>;
+    mapping?: PathMapping;
 };
 
 export interface FieldProps<
@@ -125,7 +126,7 @@ export function createField<
     readOnly = false,
     autoComplete,
     validator = emptyRule,
-    mapping = new PathMapping(camelCasePath(path)),
+    mapping = new DefaultPathMapping(camelCasePath(path)),
     format = {
         bind: x => (isValued(x) ? (x as F) : undefined),
         unbind: x =>

--- a/src/components/form/fields/consentField.tsx
+++ b/src/components/form/fields/consentField.tsx
@@ -8,7 +8,7 @@ import { MarkdownContent } from '../../miscComponent';
 import { createField, type FieldComponentProps, type FieldDefinition } from '../fieldCreator';
 import { Checkbox } from '../formControlsComponent';
 
-import { PathMapping } from '../../../core/mapping';
+import { DefaultPathMapping } from '../../../core/mapping';
 import { checked, empty, isValidatorError } from '../../../core/validation';
 import { snakeCasePath } from '../../../helpers/transformObjectProperties';
 import { isRichFormValue } from '../../../helpers/utils';
@@ -102,7 +102,7 @@ export default function consentField({
         ...props,
         required,
         defaultValue: { granted: props.defaultValue ?? false },
-        mapping: new PathMapping(snakeCasePath(props.path ?? props.key)), // Consent key should be snake_case
+        mapping: new DefaultPathMapping(snakeCasePath(props.path ?? props.key)), // Consent key should be snake_case
         format: {
             bind: value => value,
             unbind: value =>

--- a/src/core/mapping.ts
+++ b/src/core/mapping.ts
@@ -1,6 +1,12 @@
+import { ProfileAddress } from '@reachfive/identity-core';
 import { getValue, setValue } from '../helpers/propertyHelpers';
 
-export class PathMapping {
+export interface PathMapping {
+    bind<T extends Record<string, unknown>>(model: T): unknown;
+    unbind<T extends Record<string, unknown>, V>(model: T, value: V): T | V;
+}
+
+export class DefaultPathMapping implements PathMapping {
     protected readonly modelPath: string;
 
     constructor(modelPath: string) {
@@ -13,5 +19,26 @@ export class PathMapping {
 
     unbind<T extends Record<string, unknown>, V>(model: T, value: V) {
         return setValue(model, this.modelPath, value);
+    }
+}
+
+export class AddressPathMapping implements PathMapping {
+    protected readonly property: string;
+
+    constructor(property: string) {
+        this.property = property;
+    }
+
+    private defaultIndex(model: { addresses?: ProfileAddress[] }) {
+        const defaultIndex = (model.addresses ?? []).findIndex(address => address.isDefault);
+        return defaultIndex > -1 ? defaultIndex : 0;
+    }
+
+    bind<T extends { addresses?: ProfileAddress[] }>(model: T) {
+        return getValue(model, `addresses.${this.defaultIndex(model)}.${this.property}`);
+    }
+
+    unbind<T extends { addresses?: ProfileAddress[] }, V>(model: T, value: V) {
+        return setValue(model, `addresses.${this.defaultIndex(model)}.${this.property}`, value);
     }
 }

--- a/src/helpers/propertyHelpers.ts
+++ b/src/helpers/propertyHelpers.ts
@@ -15,18 +15,41 @@ function _setValueR<T extends Record<string, unknown>, V>(
     index: number,
     value: V
 ): T | V {
-    if (index < path.length) {
-        const subObject = (object[path[index]] || {}) as Record<string, unknown>;
-
-        return {
-            ...object,
-            [path[index]]: _setValueR(subObject, path, index + 1, value),
-        };
-    } else {
+    // Si on a atteint la fin du chemin, on retourne la valeur
+    if (index === path.length) {
         return value;
     }
+
+    const key = path[index];
+    const currentValue = object[key];
+
+    // Si la clé est un nombre, on traite comme un tableau
+    if (!isNaN(Number(key))) {
+        const array = Array.isArray(object) ? object : [];
+        array[Number(key)] = _setValueR((array[Number(key)] || {}) as T, path, index + 1, value);
+        return array as unknown as T;
+    }
+
+    // Sinon on traite comme un objet
+    return {
+        ...object,
+        [key]: _setValueR((currentValue || {}) as T, path, index + 1, value),
+    };
 }
 
+/**
+ * @example
+ * setValue({}, 'a', 2) => { a: 2 }
+ * setValue({ a: 1 }, 'a', 2) => { a: 2 }
+ * setValue({ a: 1 }, 'b', 2) => { a: 1, b: 2 }
+ * setValue({ a: 1 }, 'b.c', 2) => { a: 1, b: { c: 2 } }
+ * setValue({ a: { b: { c: 1 } } }, 'a.b.c', 2) => { a: { b: { c: 2 } } }
+ * setValue({ a: { b: { c: 1 } } }, 'a.b.d', 2) => { a: { b: { c: 1, d: 2 } } }
+ * setValue({ a: 1 }, 'b.0.c', 2) => { a: 1, b: [{ c: 2 }] }
+ * setValue({ a: 1, b: [{ c: 1 }] }, 'b.0.c', 2) => { a: 1, b: [{ c: 2 }] }
+ * setValue({ a: 1, b: [{ c: 1 }] }, 'b.0.b', 2) => { a: 1, b: [{ c: 1, d: 2 }] }
+ * setValue({ a: 1, b: [{ c: 1 }] }, 'b.1.d', 2) => { a: 1, b: [{ c: 1 }, { d: 2 }] }
+ */
 export function setValue<T extends Record<string, unknown>, V>(
     object: T = {} as T,
     path: string,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -25,7 +25,10 @@ export type RequiredProperty<T, K extends keyof T> = T & {
 
 type ConsentsVersions = { consentsVersions: Record<string, ConsentVersions> };
 
-type CustomFields = { customFields?: CustomField[] };
+type CustomFields = {
+    addressFields?: CustomField[];
+    customFields?: CustomField[];
+};
 
 export type Config = CoreConfig & RemoteSettings & ConsentsVersions & CustomFields;
 

--- a/tests/components/form/fields/dateField.test.tsx
+++ b/tests/components/form/fields/dateField.test.tsx
@@ -203,7 +203,6 @@ describe('DOM testing', () => {
 
         const validator = new Validator<Date>({
             rule: value => {
-                console.log(value, differenceInYears(new Date(), value));
                 return differenceInYears(new Date(), value) >= 18;
             },
             hint: 'age.minimun',

--- a/tests/helpers/propertyHelpers.test.ts
+++ b/tests/helpers/propertyHelpers.test.ts
@@ -47,5 +47,47 @@ describe('propertyHelpers', () => {
             const result = setValue(object, 'a.b.c', 'e');
             expect(result).toEqual({ a: { b: { c: 'e' } } });
         });
+
+        test('should set new value by path (empty object)', () => {
+            expect(setValue({}, 'a', 2)).toEqual({ a: 2 });
+        });
+        test('should override an existing value by path', () => {
+            expect(setValue({ a: 1 }, 'a', 2)).toEqual({ a: 2 });
+        });
+        test('should set a new value by path', () => {
+            expect(setValue({ a: 1 }, 'b', 2)).toEqual({ a: 1, b: 2 });
+        });
+        test('should set nested new value by path', () => {
+            expect(setValue({ a: 1 }, 'b.c', 2)).toEqual({ a: 1, b: { c: 2 } });
+        });
+        test('should override nested value by path', () => {
+            expect(setValue({ a: { b: { c: 1 } } }, 'a.b.c', 2)).toEqual({ a: { b: { c: 2 } } });
+        });
+        test('should add nested value by path', () => {
+            expect(setValue({ a: { b: { c: 1 } } }, 'a.b.d', 2)).toEqual({
+                a: { b: { c: 1, d: 2 } },
+            });
+        });
+        test('should set new array value by path', () => {
+            expect(setValue({ a: 1 }, 'b.0.c', 2)).toEqual({ a: 1, b: [{ c: 2 }] });
+        });
+        test('should override array value by path', () => {
+            expect(setValue({ a: 1, b: [{ c: 1 }] }, 'b.0.c', 2)).toEqual({
+                a: 1,
+                b: [{ c: 2 }],
+            });
+        });
+        test('should update array value by path', () => {
+            expect(setValue({ a: 1, b: [{ c: 1 }] }, 'b.0.d', 2)).toEqual({
+                a: 1,
+                b: [{ c: 1, d: 2 }],
+            });
+        });
+        test('should add vaule to array by path', () => {
+            expect(setValue({ a: 1, b: [{ c: 1 }] }, 'b.1.d', 2)).toEqual({
+                a: 1,
+                b: [{ c: 1 }, { d: 2 }],
+            });
+        });
     });
 });


### PR DESCRIPTION
[CA-306](https://reach5.atlassian.net/browse/CA-306)
[CA-1183](https://reach5.atlassian.net/browse/CA-1183)

Example:
```typescript
client.showAuth({
    container: 'auth-widget',
    fields: [
      'given_name',
      'family_name',
      'phone_number',
      'gender',
      'birthdate',
      'address.addressType',
      'address.streetAddress',
      'address.locality',
      'address.postalCode',
      'address.country',
      'address.custom_fields.county', // <-- a custom address field
    ],
})
```

Details to better understand this PR:
- address fields seems to be partially implemented but it does not work at all. To avoid potential breaking change, I kept the existing naming of predefined address fields in the SDK UI code (ex: `address.postalCode`). But profile's address properties is an array and  looks like `addresses[0].postalCode`.
- field `path` property is used in `fields` API query parameter to fetch profile data, so it should match expected value according to ciam-app.
- field `mapping` property is used to map form data to a field. `AddressPathMapping` aim to map an address field to the default address of a profile (a profile can have multiple addresses and one is mark as the default one with `isDefault` property)
- actual version do not allow to manage multiple address but only rely on the default one.

[CA-306]: https://reach5.atlassian.net/browse/CA-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-1183]: https://reach5.atlassian.net/browse/CA-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ