### PR TITLE
[CA-4940] Pouvoir tracer l'origine lors d'une demande de réinitialisation de mot de passe

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,7 +63,7 @@ export default tseslint.config(
             ]
         },
         settings: {
-            polyfills: ["Promise", "fetch"],
+            polyfills: ["Promise", "fetch", "URLSearchParams"],
             react: {
                 version: "detect"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@captchafox/react": "^1.9.0",
-                "@reachfive/identity-core": "^1.38.0",
+                "@reachfive/identity-core": "^1.39.0",
                 "buffer": "^6.0.3",
                 "char-info": "0.3.2",
                 "class-variance-authority": "^0.7.1",
@@ -4864,10 +4864,9 @@
             "license": "MIT"
         },
         "node_modules/@reachfive/identity-core": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@reachfive/identity-core/-/identity-core-1.38.0.tgz",
-            "integrity": "sha512-u9ub+oU/t0pME6cfKfr4qd/D3LgNPPCn3eQWJjgn63juw/ag61S3z1nWWexHpagZScRY1Uj4sH1dYPLMQGrlvg==",
-            "license": "MIT",
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/@reachfive/identity-core/-/identity-core-1.39.0.tgz",
+            "integrity": "sha512-KdpgwJsWm1XiZm79m34OibMQktZfknR6SXi3qEW2u+oasB6q2GIg2tj+jyNopzZUnsU99N96TWMcRT+okMC4tA==",
             "dependencies": {
                 "buffer": "5.6.0",
                 "winchan": "0.2.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@captchafox/react": "^1.9.0",
-        "@reachfive/identity-core": "^1.38.0",
+        "@reachfive/identity-core": "^1.39.0",
         "buffer": "^6.0.3",
         "char-info": "0.3.2",
         "class-variance-authority": "^0.7.1",

--- a/src/components/form/passwordSignupFormComponent.tsx
+++ b/src/components/form/passwordSignupFormComponent.tsx
@@ -26,14 +26,48 @@ const SignupForm = createForm<SignupParams['data']>({
 });
 
 export interface PasswordSignupFormProps {
+    /**
+     * List of authentication options
+     */
     auth?: AuthOptions;
+    /**
+     * A function that is called before the signup request is made.
+     */
     beforeSignup?: <T>(param: T) => T;
+    /**
+     * Whether or not to provide the display password in clear text option.
+     * @default false
+     */
     canShowPassword?: boolean;
+    /**
+     * Object that lets you set display options for the phone number field.
+     */
     phoneNumberOptions?: PhoneNumberOptions;
+    /**
+     * The URL sent in the email to which the user is redirected. This URL must be whitelisted in the `Allowed Callback URLs` field of your ReachFive client settings.
+     */
     redirectUrl?: string;
+    /**
+     * Returned in the `redirectUrl` as a query parameter, this parameter is used as the post-email confirmation URL.
+     */
     returnToAfterEmailConfirmation?: string;
+    /**
+     * Boolean for whether the signup form fields' labels are displayed on the login view.
+     * @default false
+     * If set to `true`, the labels are shown which includes an asterisk (*) next to required fields.
+     */
     showLabels?: boolean;
+    /**
+     * List of the signup fields to display in the form.
+     *
+     * A field is either a string representing the field’s key (predefined, custom field, or consent) or an object with attributes overriding the default field configuration.
+     *
+     * @default ['given_name', 'family_name', 'email', 'password', 'password_confirmation']
+     */
     signupFields?: (string | Field)[];
+    /**
+     * The user agreement text to display in the form.
+     */
     userAgreement?: string;
     /**
      * Callback function called when the request has succeed.

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -98,7 +98,7 @@ export function enrichLoginEvent<T extends LoginWithPasswordParams | LoginWithWe
 ): LoginEventWrappingObject {
     switch (authType) {
         case 'password':
-        case 'webauthn':
+        case 'webauthn': {
             const identifierType: IdentifierType =
                 data != undefined
                     ? 'email' in data
@@ -108,6 +108,7 @@ export function enrichLoginEvent<T extends LoginWithPasswordParams | LoginWithWe
                           : 'custom_identifier'
                     : 'email';
             return { authResult, authType, identifierType };
+        }
         default:
             return { authResult, authType };
     }

--- a/src/widgets/auth/views/forgotPasswordViewComponent.tsx
+++ b/src/widgets/auth/views/forgotPasswordViewComponent.tsx
@@ -166,6 +166,10 @@ export interface ForgotPasswordViewProps {
      */
     returnToAfterPasswordReset?: string;
     /**
+     * The origin of the request.
+     */
+    origin?: string;
+    /**
      * Callback function called when the request has succeed.
      */
     onSuccess?: OnSuccess;
@@ -187,6 +191,7 @@ export const ForgotPasswordView = ({
     captchaFoxEnabled = false,
     captchaFoxMode = 'hidden',
     captchaFoxSiteKey,
+    origin,
     redirectUrl,
     returnToAfterPasswordReset,
     onError = (() => {}) as OnError,
@@ -200,6 +205,7 @@ export const ForgotPasswordView = ({
     const callback = (data: ForgotPasswordEmailFormData) =>
         coreClient.requestPasswordReset({
             ...data,
+            origin,
             redirectUrl,
             returnToAfterPasswordReset,
         });

--- a/src/widgets/auth/views/signupWithWebAuthnViewComponent.tsx
+++ b/src/widgets/auth/views/signupWithWebAuthnViewComponent.tsx
@@ -48,14 +48,19 @@ export interface SignupWithWebAuthnViewProps {
     /**
      * List of the signup fields to display in the form.
      *
-     * You can pass a field as an object to override default values :
+     * A field is either a string representing the field’s key (predefined, custom field, or consent) or an object with attributes overriding the default field configuration.
+     *
+     * @default ['given_name', 'family_name', 'email']
      *
      * @example
-     * {
-     *   "key": "family_name",
-     *   "defaultValue": "Moreau",
-     *   "required": true
-     * }
+     * [
+     *   "email",
+     *   {
+     *     "key": "family_name",
+     *     "defaultValue": "Moreau",
+     *     "required": true
+     *   }
+     * ]
      */
     signupFields?: (string | Field)[];
     /**  */

--- a/types/identity-ui.d.ts
+++ b/types/identity-ui.d.ts
@@ -1,6 +1,6 @@
 /**
- * @reachfive/identity-ui - v1.35.0
- * Compiled Thu, 10 Jul 2025 11:59:04 UTC
+ * @reachfive/identity-ui - v1.37.0
+ * Compiled Tue, 07 Oct 2025 08:48:20 UTC
  *
  * Copyright (c) ReachFive.
  *
@@ -13,8 +13,8 @@ export { Config } from '@reachfive/identity-core';
 import * as React from 'react';
 import React__default, { CSSProperties, ComponentType, ComponentProps } from 'react';
 import { StepUpPasswordlessParams as StepUpPasswordlessParams$1 } from '@reachfive/identity-core/es/main/oAuthClient';
-import { Country, Value as Value$2 } from 'react-phone-number-input';
 import { WidgetDisplayMode } from '@captchafox/types';
+import { Country, Value as Value$2 } from 'react-phone-number-input';
 import * as libphonenumber_js from 'libphonenumber-js';
 
 type IdentifierType = 'email' | 'phone_number' | 'custom_identifier'
@@ -855,6 +855,7 @@ interface MainViewProps$5 {
 }
 type FaSelectionViewState = MFA.StepUpResponse & {
     allowTrustDevice?: boolean;
+    auth?: AuthOptions;
 };
 type FaSelectionViewProps = Prettify<Partial<MFA.StepUpResponse> & {
     showIntro?: boolean;
@@ -990,6 +991,10 @@ interface ForgotPasswordViewProps {
      */
     returnToAfterPasswordReset?: string;
     /**
+     * The origin of the request.
+     */
+    origin?: string;
+    /**
      * Callback function called when the request has succeed.
      */
     onSuccess?: OnSuccess;
@@ -998,7 +1003,7 @@ interface ForgotPasswordViewProps {
      */
     onError?: OnError;
 }
-declare const ForgotPasswordView: ({ allowLogin, allowPhoneNumberResetPassword, displaySafeErrorMessage, showLabels, allowWebAuthnLogin, initialScreen, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxMode, captchaFoxSiteKey, redirectUrl, returnToAfterPasswordReset, onError, onSuccess, }: WithCaptchaProps<ForgotPasswordViewProps>) => React__default.JSX.Element;
+declare const ForgotPasswordView: ({ allowLogin, allowPhoneNumberResetPassword, displaySafeErrorMessage, showLabels, allowWebAuthnLogin, initialScreen, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxMode, captchaFoxSiteKey, origin, redirectUrl, returnToAfterPasswordReset, onError, onSuccess, }: WithCaptchaProps<ForgotPasswordViewProps>) => React__default.JSX.Element;
 
 type LoginViewProps = {
     /**
@@ -1094,7 +1099,7 @@ type LoginViewProps = {
      */
     action?: string;
 };
-declare const LoginView: ({ acceptTos, allowForgotPassword, allowSignup, allowWebAuthnLogin, allowAccountRecovery, auth, canShowPassword, socialProviders, allowCustomIdentifier, showLabels, showRememberMe, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxSiteKey, captchaFoxMode, allowAuthentMailPhone, allowTrustDevice, onError, onSuccess, }: WithCaptchaProps<LoginViewProps>) => React__default.JSX.Element;
+declare const LoginView: ({ acceptTos, allowForgotPassword, allowSignup, allowWebAuthnLogin, allowAccountRecovery, auth, canShowPassword, socialProviders, allowCustomIdentifier, showLabels, showRememberMe, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxSiteKey, captchaFoxMode, allowAuthentMailPhone, allowTrustDevice, action, onError, onSuccess, }: WithCaptchaProps<LoginViewProps>) => React__default.JSX.Element;
 
 interface LoginWithPasswordViewProps {
     allowForgotPassword?: boolean;
@@ -1117,7 +1122,7 @@ interface LoginWithPasswordViewProps {
      */
     action?: string;
 }
-declare const LoginWithPasswordView: ({ allowForgotPassword, allowAccountRecovery, auth, canShowPassword, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxSiteKey, captchaFoxMode, showLabels, showRememberMe, allowTrustDevice, onError, onSuccess, }: WithCaptchaProps<LoginWithPasswordViewProps>) => React__default.JSX.Element;
+declare const LoginWithPasswordView: ({ allowForgotPassword, allowAccountRecovery, auth, canShowPassword, recaptcha_enabled, recaptcha_site_key, captchaFoxEnabled, captchaFoxSiteKey, captchaFoxMode, showLabels, showRememberMe, allowTrustDevice, action, onError, onSuccess, }: WithCaptchaProps<LoginWithPasswordViewProps>) => React__default.JSX.Element;
 
 interface LoginWithWebAuthnViewProps {
     /**
@@ -1225,17 +1230,51 @@ interface ReauthViewProps {
      */
     action?: string;
 }
-declare const ReauthView: ({ allowForgotPassword, auth, session, showLabels, socialProviders, onError, onSuccess, }: PropsWithSession<ReauthViewProps>) => React__default.JSX.Element | null;
+declare const ReauthView: ({ allowForgotPassword, auth, session, showLabels, socialProviders, action, onError, onSuccess, }: PropsWithSession<ReauthViewProps>) => React__default.JSX.Element | null;
 
 interface PasswordSignupFormProps {
+    /**
+     * List of authentication options
+     */
     auth?: AuthOptions;
+    /**
+     * A function that is called before the signup request is made.
+     */
     beforeSignup?: <T>(param: T) => T;
+    /**
+     * Whether or not to provide the display password in clear text option.
+     * @default false
+     */
     canShowPassword?: boolean;
+    /**
+     * Object that lets you set display options for the phone number field.
+     */
     phoneNumberOptions?: PhoneNumberOptions;
+    /**
+     * The URL sent in the email to which the user is redirected. This URL must be whitelisted in the `Allowed Callback URLs` field of your ReachFive client settings.
+     */
     redirectUrl?: string;
+    /**
+     * Returned in the `redirectUrl` as a query parameter, this parameter is used as the post-email confirmation URL.
+     */
     returnToAfterEmailConfirmation?: string;
+    /**
+     * Boolean for whether the signup form fields' labels are displayed on the login view.
+     * @default false
+     * If set to `true`, the labels are shown which includes an asterisk (*) next to required fields.
+     */
     showLabels?: boolean;
+    /**
+     * List of the signup fields to display in the form.
+     *
+     * A field is either a string representing the field’s key (predefined, custom field, or consent) or an object with attributes overriding the default field configuration.
+     *
+     * @default ['given_name', 'family_name', 'email', 'password', 'password_confirmation']
+     */
     signupFields?: (string | Field)[];
+    /**
+     * The user agreement text to display in the form.
+     */
     userAgreement?: string;
     /**
      * Callback function called when the request has succeed.
@@ -1277,14 +1316,19 @@ interface SignupWithWebAuthnViewProps {
     /**
      * List of the signup fields to display in the form.
      *
-     * You can pass a field as an object to override default values :
+     * A field is either a string representing the field’s key (predefined, custom field, or consent) or an object with attributes overriding the default field configuration.
+     *
+     * @default ['given_name', 'family_name', 'email']
      *
      * @example
-     * {
-     *   "key": "family_name",
-     *   "defaultValue": "Moreau",
-     *   "required": true
-     * }
+     * [
+     *   "email",
+     *   {
+     *     "key": "family_name",
+     *     "defaultValue": "Moreau",
+     *     "required": true
+     *   }
+     * ]
      */
     signupFields?: (string | Field)[];
     /**  */


### PR DESCRIPTION
[CA-4940](https://reach5.atlassian.net/browse/CA-4940)

Depends on https://github.com/ReachFive/identity-web-core-sdk/pull/272 and https://github.com/ReachFive/ciam-app/pull/5597

[CA-4940]: https://reach5.atlassian.net/browse/CA-4940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ