### PR TITLE
fix: use correct secret name for NPM token

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Publish to NPM
         run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
The deploy workflow was referencing `secrets.NPM_TOKEN` but the secret is named `NODE_AUTH_TOKEN`. This caused `ENEEDAUTH` on npm publish.