### PR TITLE
test: fix React act() warning in mfaStepUpWidget tests

### DIFF
--- a/tests/widgets/mfa/mfaStepUpWidget.test.ts
+++ b/tests/widgets/mfa/mfaStepUpWidget.test.ts
@@ -165,9 +165,7 @@ describe('DOM testing', () => {
         expect(onError).not.toBeCalled();
 
         await waitFor(() =>
-            expect(window.location.replace).toHaveBeenCalledWith(
-                expect.stringContaining(auth.redirectUri)
-            )
+            expect(replaceMock).toHaveBeenCalledWith(expect.stringContaining(auth.redirectUri))
         );
     };
 

--- a/tests/widgets/mfa/mfaStepUpWidget.test.ts
+++ b/tests/widgets/mfa/mfaStepUpWidget.test.ts
@@ -101,7 +101,12 @@ describe('DOM testing', () => {
             { onError, onSuccess, ...options },
             { apiClient, config: { ...defaultConfig, ...config }, defaultI18n }
         );
-        return render(result);
+        const view = render(result);
+        // Flush any state update triggered by a useEffect-initiated async call on
+        // mount (e.g. showStepUpStart: false), so it lands inside this act()
+        // boundary instead of racing with the test's first await on this function.
+        await waitFor(() => {});
+        return view;
     };
 
     const assertStepUpWorkflow = async (user: UserEvent, amr: string[]) => {
@@ -197,7 +202,10 @@ describe('DOM testing', () => {
         });
 
         test('showStepUpStart: false', async () => {
-            expect.assertions(12);
+            // 11, not 12: generateComponent now settles the mount-triggered
+            // getMfaStepUpToken call before returning, so the startPasswordless
+            // waitFor below succeeds on its first check instead of needing a retry.
+            expect.assertions(11);
 
             const user = userEvent.setup();
 

--- a/tests/widgets/mfa/mfaStepUpWidget.test.ts
+++ b/tests/widgets/mfa/mfaStepUpWidget.test.ts
@@ -103,8 +103,9 @@ describe('DOM testing', () => {
         );
         const view = render(result);
         // Flush any state update triggered by a useEffect-initiated async call on
-        // mount (e.g. showStepUpStart: false), so it lands inside this act()
-        // boundary instead of racing with the test's first await on this function.
+        // mount (e.g. showStepUpStart: false): waitFor() wraps its polling in
+        // act(), so the update resolves here instead of racing with the test's
+        // first await on this function.
         await waitFor(() => {});
         return view;
     };


### PR DESCRIPTION
## Summary
- Fixes a React `act()` warning printed during `npm test`, originating at `src/widgets/stepUp/mfaStepUpWidget.tsx:95` (`setResponse(res)` inside `onGetStepUpToken`).
- Root cause: when `showStepUpStart: false`, `MainView` kicks off `onGetStepUpToken()` from a `useEffect` on mount. The mocked API promise resolves in a microtask that lands during the test helper's `await generateComponent(...)`, i.e. after RTL's `render()` synchronous `act()` scope has already closed — so the resulting `setResponse` state update is unwrapped and React warns.
- Fix: `generateComponent` now does `await waitFor(() => {})` right after `render()`, flushing any mount-triggered async state update inside an `act()` boundary before the test proceeds. No `act()` wrapping was added to the component itself.
- Side effect (expected, not a behavior change): eliminating this race means the `startPasswordless` `waitFor` in the single-amr `showStepUpStart: false` test now succeeds on its first check instead of needing one failed-then-retried check, so `expect.assertions(12)` correctly becomes `expect.assertions(11)`. Verified by instrumenting the retry count before/after the fix — same assertions, one fewer incidental retry.
- No production code changed; no test assertions removed or altered in meaning.

## Test plan
- [x] `npx jest tests/widgets/mfa/mfaStepUpWidget.test.ts` — 4/4 pass, no `act()` warning
- [x] `npm test` (full suite) — 255/255 pass, 29/29 suites, no new warnings
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (unrelated pre-existing warnings only)
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)