### PR TITLE
fix: resolve ESLint errors in tests/

### DIFF
--- a/tests/components/form/fields/date.test.tsx
+++ b/tests/components/form/fields/date.test.tsx
@@ -52,6 +52,10 @@ const defaultI18n: I18nMessages = {
     day: 'Jour',
 };
 
+// Wrapped in an arrow function (rather than passing `jest.advanceTimersByTime`
+// directly) to avoid an @typescript-eslint/unbound-method lint error.
+const advanceTimersByTime = (ms: number) => jest.advanceTimersByTime(ms);
+
 describe('DOM testing', () => {
     beforeEach(() => {
         jest.useFakeTimers();
@@ -63,7 +67,7 @@ describe('DOM testing', () => {
     });
 
     test('default settings — triggers render and locale ordering', async () => {
-        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+        const user = userEvent.setup({ advanceTimers: advanceTimersByTime });
         const onChange = jest.fn();
 
         render(
@@ -124,7 +128,7 @@ describe('DOM testing', () => {
     });
 
     test('onChange fires with ISO string when all parts selected', async () => {
-        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+        const user = userEvent.setup({ advanceTimers: advanceTimersByTime });
         const onChange = jest.fn();
 
         render(
@@ -158,7 +162,7 @@ describe('DOM testing', () => {
     });
 
     test('day options update when month changes', async () => {
-        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+        const user = userEvent.setup({ advanceTimers: advanceTimersByTime });
         const onChange = jest.fn();
 
         render(

--- a/tests/components/form/fields/input.test.tsx
+++ b/tests/components/form/fields/input.test.tsx
@@ -94,7 +94,7 @@ describe('DOM testing', () => {
         expect(input).toHaveValue(newValue);
     });
 
-    test('custom type, placeholder and default value', async () => {
+    test('custom type, placeholder and default value', () => {
         const onChange = jest.fn();
 
         render(

--- a/tests/components/form/form.test.tsx
+++ b/tests/components/form/form.test.tsx
@@ -182,7 +182,7 @@ describe('DOM testing', () => {
             const configWithSnakeCaseField: Config = {
                 ...defaultConfig,
                 customFields: [
-                    ...defaultConfig.customFields!,
+                    ...defaultConfig.customFields,
                     {
                         name: 'Display Name',
                         path: 'display_name',

--- a/tests/widgets/accountRecovery/accountRecovery.test.ts
+++ b/tests/widgets/accountRecovery/accountRecovery.test.ts
@@ -89,7 +89,7 @@ describe('DOM testing', () => {
             { config: { ...defaultConfig, ...config }, apiClient, defaultI18n }
         );
 
-        return waitFor(async () => {
+        return waitFor(() => {
             return render(result);
         });
     };
@@ -118,7 +118,7 @@ describe('DOM testing', () => {
             );
 
             expect(
-                screen.queryByText('accountRecovery.passkeyReset.successMessage')
+                screen.getByText('accountRecovery.passkeyReset.successMessage')
             ).toBeInTheDocument();
 
             expect(onSuccess).toBeCalledWith(
@@ -177,7 +177,7 @@ describe('DOM testing', () => {
                 })
             );
 
-            expect(screen.queryByText('passwordReset.successMessage')).toBeInTheDocument();
+            expect(screen.getByText('passwordReset.successMessage')).toBeInTheDocument();
 
             expect(onSuccess).toBeCalledWith(
                 expect.objectContaining({

--- a/tests/widgets/emailEditor/emailEditorWidget.test.ts
+++ b/tests/widgets/emailEditor/emailEditorWidget.test.ts
@@ -62,10 +62,12 @@ describe('Snapshot', () => {
                 { apiClient, config: { ...defaultConfig, ...config }, defaultI18n }
             );
 
-            await waitFor(async () => {
-                const { container } = await render(widget);
-                expect(container).toMatchSnapshot();
-            });
+            const { container } = render(widget);
+            // Flush any state update triggered by a useEffect-initiated async call on
+            // mount, so it lands inside this act() boundary instead of racing with
+            // the snapshot assertion below.
+            await waitFor(() => {});
+            expect(container).toMatchSnapshot();
         };
 
     describe('email editor', () => {
@@ -99,9 +101,12 @@ describe('DOM testing', () => {
             { config: { ...defaultConfig, ...config }, apiClient, defaultI18n }
         );
 
-        return waitFor(async () => {
-            return render(result);
-        });
+        const view = render(result);
+        // Flush any state update triggered by a useEffect-initiated async call on
+        // mount, so it lands inside this act() boundary instead of racing with
+        // the test's first await on this function.
+        await waitFor(() => {});
+        return view;
     };
 
     describe('emailEditor', () => {

--- a/tests/widgets/mfa/mfaListWidget.test.ts
+++ b/tests/widgets/mfa/mfaListWidget.test.ts
@@ -65,15 +65,13 @@ describe('Snapshot', () => {
                 { apiClient, config: { ...defaultConfig, ...config }, defaultI18n }
             );
 
-            await waitFor(async () => {
-                const { container, rerender } = await render(widget);
+            const { container, rerender } = render(widget);
 
-                await waitFor(() => expect(apiClient.listMfaCredentials).toHaveBeenCalled());
+            await waitFor(() => expect(apiClient.listMfaCredentials).toHaveBeenCalled());
 
-                rerender(widget);
+            rerender(widget);
 
-                expect(container).toMatchSnapshot();
-            });
+            expect(container).toMatchSnapshot();
         };
 
     test('empty', generateSnapshot({}, undefined, []));
@@ -121,9 +119,12 @@ describe('DOM testing', () => {
             { accessToken: 'azerty', onError, onSuccess, ...options },
             { apiClient, config: { ...defaultConfig, ...config }, defaultI18n }
         );
-        return await waitFor(async () => {
-            return render(result);
-        });
+        const view = render(result);
+        // Flush any state update triggered by a useEffect-initiated async call on
+        // mount (e.g. listMfaCredentials), so it lands inside this act() boundary
+        // instead of racing with the test's first await on this function.
+        await waitFor(() => {});
+        return view;
     };
 
     describe('mfaCredentials', () => {

--- a/tests/widgets/mfa/trustedDevicesWidget.test.ts
+++ b/tests/widgets/mfa/trustedDevicesWidget.test.ts
@@ -73,7 +73,12 @@ describe('DOM testing', () => {
                 defaultI18n,
             }
         );
-        return await waitFor(async () => render(result));
+        const view = render(result);
+        // Flush any state update triggered by a useEffect-initiated async call on
+        // mount (e.g. listTrustedDevices), so it lands inside this act() boundary
+        // instead of racing with the test's first await on this function.
+        await waitFor(() => {});
+        return view;
     };
 
     describe('trustedDevices', () => {

--- a/tests/widgets/socialLogin/socialLogin.test.ts
+++ b/tests/widgets/socialLogin/socialLogin.test.ts
@@ -59,10 +59,12 @@ describe('Snapshot', () => {
                 defaultI18n,
             });
 
-            await waitFor(async () => {
-                const { container } = await render(widget);
-                expect(container).toMatchSnapshot();
-            });
+            const { container } = render(widget);
+            // Flush any state update triggered by a useEffect-initiated async call on
+            // mount, so it lands inside this act() boundary instead of racing with
+            // the snapshot assertion below.
+            await waitFor(() => {});
+            expect(container).toMatchSnapshot();
         };
 
     describe('social login', () => {
@@ -107,7 +109,7 @@ describe('DOM testing', () => {
         await generateComponent({});
 
         defaultConfig.socialProviders.forEach(provider => {
-            expect(screen.queryByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
+            expect(screen.getByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
         });
 
         const provider = defaultConfig.socialProviders[0] as ProviderId;
@@ -133,7 +135,7 @@ describe('DOM testing', () => {
         });
 
         defaultConfig.socialProviders.forEach(provider => {
-            expect(screen.queryByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
+            expect(screen.getByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
         });
     });
 
@@ -146,7 +148,7 @@ describe('DOM testing', () => {
         await generateComponent({});
 
         defaultConfig.socialProviders.forEach(provider => {
-            expect(screen.queryByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
+            expect(screen.getByTitle(providers[provider as ProviderId].name)).toBeInTheDocument();
         });
 
         const provider = defaultConfig.socialProviders[0] as ProviderId;

--- a/tests/widgets/webAuthn/webAuthnDevicesWidget.test.ts
+++ b/tests/widgets/webAuthn/webAuthnDevicesWidget.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest-styled-components';
 
@@ -87,7 +87,7 @@ describe('DOM testing', () => {
             { config: { ...defaultConfig, ...config }, apiClient, defaultI18n }
         );
 
-        return waitFor(async () => {
+        return waitFor(() => {
             return render(result);
         });
     };
@@ -169,11 +169,13 @@ describe('DOM testing', () => {
             const deviceNames = screen.queryAllByTestId('device-name').map(el => el.textContent);
             expect(deviceNames).toEqual(['myOldDevice', 'myNewDevice']);
 
-            const oldDevice = devicesAfterAdd.find(el => el.textContent === 'myOldDevice');
-            const removeOldDevice = oldDevice?.querySelector('[data-testid="device-remove"]');
+            const oldDevice = devicesAfterAdd.find(
+                el => within(el).getByTestId('device-name').textContent === 'myOldDevice'
+            );
+            const removeOldDevice = within(oldDevice!).getByTestId('device-remove');
             expect(removeOldDevice).toBeInTheDocument();
 
-            await user.click(removeOldDevice!);
+            await user.click(removeOldDevice);
 
             expect(confirmMock).toBeCalled();
 
@@ -236,11 +238,13 @@ describe('DOM testing', () => {
             await generateComponent({});
 
             const devices = screen.queryAllByTestId('device');
-            const oldDevice = devices.find(el => el.textContent === 'myOldDevice');
-            const removeOldDevice = oldDevice?.querySelector('[data-testid="device-remove"]');
+            const oldDevice = devices.find(
+                el => within(el).getByTestId('device-name').textContent === 'myOldDevice'
+            );
+            const removeOldDevice = within(oldDevice!).getByTestId('device-remove');
             expect(removeOldDevice).toBeInTheDocument();
 
-            await user.click(removeOldDevice!);
+            await user.click(removeOldDevice);
 
             expect(confirmMock).toBeCalled();
 


### PR DESCRIPTION
## Summary
- Fixes all 30 ESLint errors across 9 files under `tests/` (see rule breakdown below). No production code changed; no test assertions removed or altered in meaning.
- `@typescript-eslint/unbound-method` (date.test.tsx): wrapped `jest.advanceTimersByTime` in a local arrow function instead of passing the method reference directly.
- `@typescript-eslint/require-await` (multiple files): removed `async` from callbacks that never awaited anything.
- `@typescript-eslint/no-unnecessary-type-assertion` (form.test.tsx, webAuthnDevicesWidget.test.ts): removed redundant assertions.
- `testing-library/prefer-presence-queries` (accountRecovery.test.ts, socialLogin.test.ts): changed `queryBy*` to `getBy*` for presence checks.
- `testing-library/no-wait-for-side-effects` / `no-wait-for-snapshot` / `@typescript-eslint/await-thenable` (emailEditorWidget.test.ts, mfaListWidget.test.ts, trustedDevicesWidget.test.ts, socialLogin.test.ts): moved `render`/`rerender`/`toMatchSnapshot()` out of `waitFor` callbacks, using an empty `await waitFor(() => {})` afterwards to flush any mount-triggered async state — same pattern established in #358 for `mfaStepUpWidget.test.ts`.
- `testing-library/no-node-access` (webAuthnDevicesWidget.test.ts): replaced raw `querySelector` DOM traversal with `within(...).getByTestId(...)`.

## Test plan
- [x] `npx eslint tests/` — 0 errors
- [x] `npm test` (full suite) — 255/255 pass, 29/29 suites, 40/40 snapshots unchanged
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)