### PR TITLE
test: silence expected console.error noise in form tests

### DIFF
--- a/tests/components/form/form.test.tsx
+++ b/tests/components/form/form.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-import { describe, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -567,6 +567,19 @@ describe('DOM testing', () => {
     });
 
     describe('Error Handling', () => {
+        // AppError submissions make the Form call logError(), which logs to
+        // console.error by design (src/helpers/logger.ts). Silence it here so
+        // the expected error path doesn't pollute test output.
+        let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+        beforeEach(() => {
+            consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            consoleErrorSpy.mockRestore();
+        });
+
         test('onError called when handler throws a generic error', async () => {
             const user = userEvent.setup();
             const onError = jest.fn<(err: unknown) => void>();


### PR DESCRIPTION
## Summary
- `Form`'s error handler (`src/components/form/form.tsx:153`) intentionally calls `logError()` (`src/helpers/logger.ts`), which writes to `console.error` whenever a submission rejects with an `AppError`.
- Three tests in `tests/components/form/form.test.tsx`'s `Error Handling` describe block trigger this path on purpose to verify the error UI, which printed real `console.error` noise during `npm test` even though nothing was broken.
- Added a `beforeEach`/`afterEach` in that block that spies on and mocks `console.error`, scoped only to those tests so genuinely unexpected console errors elsewhere still surface.

## Test plan
- [x] `npx jest tests/components/form/form.test.tsx` — 41/41 passing, no `console.error` output
- [x] `npm run typecheck`